### PR TITLE
fix: force flac output format in writeFlacTags — tagging always failed and downloads were deleted

### DIFF
--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -818,7 +818,10 @@ export class MetadataService {
                 );
             }
 
-            args.push(tempPath);
+            // The temp output ends in `.tmp`, so ffmpeg cannot guess the output
+            // muxer from the extension — force it, or every tag write fails with
+            // "Unable to find a suitable output format".
+            args.push('-f', 'flac', tempPath);
 
             await new Promise<void>((resolve, reject) => {
                 execFile(ffmpeg, args, { timeout: 60000 }, (error, _stdout, stderr) => {


### PR DESCRIPTION
## Problem
Every FLAC download completes and is then **deleted**. `missing_tracks.txt` shows the same error for every track:

```
Error: ffmpeg tagging failed:   Duration: N/A, start: 0.000000, bitrate: N/A
[NULL @ 0x132608310] Unable to find a suitable output format for '/Users/.../02. Georgia On My Mind.flac.51206-1785067026336-bd6qb0a1t1o.tmp'
```

Because tagging fails, the downloader treats the track as failed and removes the file — a whole playlist ends with `Batch download failed` and nothing on disk.

## Root cause
`writeFlacTags()` writes the ffmpeg output to `${filePath}.${uniqueSuffix}.tmp`. ffmpeg selects the **output muxer from the output file's extension**, and `.tmp` matches no known format, so every tag write fails. This has been present since the switch from `flac-metadata` to ffmpeg tagging (`17d5dcc`) and is unrelated to the Windows command-line-length fix (#57) — though it may explain the other truncated ffmpeg errors in that report.

Standalone repro (no app needed):

```bash
ffmpeg -y -f lavfi -i "sine=frequency=440:duration=1" -c:a flac test.flac
printf ';FFMETADATA1\ntitle=Test\n' > meta.txt

# current code path — fails:
ffmpeg -y -i test.flac -f ffmetadata -i meta.txt -map 0:0 -map_metadata 1 -c copy test.flac.12345.tmp
# → Unable to find a suitable output format for 'test.flac.12345.tmp'

# with explicit output format — works:
ffmpeg -y -i test.flac -f ffmetadata -i meta.txt -map 0:0 -map_metadata 1 -c copy -f flac test.flac.12345.tmp
```

## Fix
Force the output muxer with `-f flac` before the output path — the output is always FLAC here (`-c copy` from a FLAC input). One line, covers both the cover-art and metadata-only branches.

## Testing
- Verified on macOS arm64 (ffmpeg 8.1.2): a 37-track playlist now downloads, tags (metadata + cover art + lyrics), and keeps every file; before the fix, all 37 were deleted.
- `tsc` passes; full test suite passes (213 tests).
