### PR TITLE
fix: never leave a track with no copy on disk when tagging or a sidecar write fails

### DIFF
--- a/src/services/download.ts
+++ b/src/services/download.ts
@@ -470,7 +470,16 @@ export default class DownloadService {
 
             if (lrcContent !== null) {
                 const lrcPath = filePath.replace(/\.[^.]+$/, '.lrc');
-                writeFileSync(lrcPath, lrcContent, 'utf8');
+                try {
+                    writeFileSync(lrcPath, lrcContent, 'utf8');
+                } catch (error: unknown) {
+                    // A sidecar must never take the track with it: the catch at the
+                    // end of this method deletes the audio file on any throw, so an
+                    // unwritable .lrc (read-only share, full disk) would discard a
+                    // download that had already completed, verified and tagged.
+                    const message = error instanceof Error ? error.message : String(error);
+                    logger.warn(`Failed to write .lrc sidecar, keeping track: ${message}`, 'LYRICS');
+                }
             }
 
             let finalFilePath = filePath;
@@ -498,6 +507,10 @@ export default class DownloadService {
             const message = error instanceof Error ? error.message : String(error);
             const cleanupPath = shouldReplaceExisting ? workingFilePath : filePath;
             if (existsSync(cleanupPath) && (!this.pathsEqual(cleanupPath, filePath) || !shouldReplaceExisting)) {
+                // Log before discarding: this deletion is silent otherwise, so a
+                // late-stage failure looks to the user like the file was never
+                // downloaded at all.
+                logger.warn(`Removing incomplete download "${cleanupPath}": ${message}`, 'DOWNLOAD');
                 unlinkSync(cleanupPath);
             }
             resumeService.completeDownload(trackId.toString());

--- a/src/services/metadata.file-swap.test.ts
+++ b/src/services/metadata.file-swap.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { MetadataService } from './metadata.js';
+
+// ffmpeg is simulated: it writes a plausible output file at the path given as the
+// final argument. The point of this suite is the *file swap* around that call --
+// the step that replaces the user's original track with the tagged copy -- which
+// every other test mocks away behind vi.mock('fs').
+vi.mock('child_process', async () => {
+    const realFs = await vi.importActual<typeof import('fs')>('fs');
+    return {
+        execFile: vi.fn((_file: string, args: string[], _opts: unknown, cb: Function) => {
+            realFs.writeFileSync(args[args.length - 1]!, Buffer.alloc(4096, 7));
+            cb(null, '', '');
+        })
+    };
+});
+
+vi.mock('../utils/binaries.js', () => ({
+    resolveBinaryPath: vi.fn(() => 'ffmpeg')
+}));
+
+vi.mock('../utils/logger.js', () => ({
+    logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+const ORIGINAL_CONTENT = Buffer.alloc(2048, 42);
+const TAGS = [['TITLE', 'T'], ['ARTIST', 'A']];
+
+describe('writeFlacTags file swap', () => {
+    let service: MetadataService;
+    let dir: string;
+    let track: string;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        service = new MetadataService();
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qbz-swap-'));
+        track = path.join(dir, 'track.flac');
+        fs.writeFileSync(track, ORIGINAL_CONTENT);
+    });
+
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('replaces the original with the tagged file and leaves no temp files behind', async () => {
+        await service.writeFlacTags(track, TAGS);
+
+        expect(fs.existsSync(track)).toBe(true);
+        expect(fs.readFileSync(track).equals(ORIGINAL_CONTENT)).toBe(false);
+        expect(fs.readdirSync(dir)).toEqual(['track.flac']);
+    });
+
+    it('keeps the original when the tagged file cannot be moved into place', async () => {
+        // Fail the move of the tagged temp file into place -- an SMB lock or a
+        // transient EPERM at exactly the wrong moment. Backing the original up
+        // first means it can be restored; the previous order unlinked it before
+        // this rename, so the failure left no copy of the track on disk at all.
+        const realRename = fs.renameSync;
+        const spy = vi.spyOn(fs, 'renameSync').mockImplementation((from, to) => {
+            if (String(from).endsWith('.tmp')) throw new Error('EPERM: rename blocked');
+            return realRename(from, to);
+        });
+
+        await expect(service.writeFlacTags(track, TAGS)).rejects.toThrow('EPERM: rename blocked');
+
+        expect(fs.existsSync(track)).toBe(true);
+        expect(fs.readFileSync(track).equals(ORIGINAL_CONTENT)).toBe(true);
+        spy.mockRestore();
+    });
+
+    it('keeps the original untouched when ffmpeg fails', async () => {
+        vi.mocked(execFile).mockImplementationOnce(((
+            _file: string,
+            _args: string[],
+            _opts: unknown,
+            cb: Function
+        ) => {
+            cb(new Error('exited 1'), '', 'Unable to find a suitable output format');
+        }) as unknown as typeof execFile);
+
+        await expect(service.writeFlacTags(track, TAGS)).rejects.toThrow('ffmpeg tagging failed');
+
+        expect(fs.existsSync(track)).toBe(true);
+        expect(fs.readFileSync(track).equals(ORIGINAL_CONTENT)).toBe(true);
+        expect(fs.readdirSync(dir)).toEqual(['track.flac']);
+    });
+});

--- a/src/services/metadata.file-swap.test.ts
+++ b/src/services/metadata.file-swap.test.ts
@@ -9,10 +9,12 @@ import { MetadataService } from './metadata.js';
 // final argument. The point of this suite is the *file swap* around that call --
 // the step that replaces the user's original track with the tagged copy -- which
 // every other test mocks away behind vi.mock('fs').
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
 vi.mock('child_process', async () => {
     const realFs = await vi.importActual<typeof import('fs')>('fs');
     return {
-        execFile: vi.fn((_file: string, args: string[], _opts: unknown, cb: Function) => {
+        execFile: vi.fn((_file: string, args: string[], _opts: unknown, cb: ExecFileCallback) => {
             realFs.writeFileSync(args[args.length - 1]!, Buffer.alloc(4096, 7));
             cb(null, '', '');
         })
@@ -78,7 +80,7 @@ describe('writeFlacTags file swap', () => {
             _file: string,
             _args: string[],
             _opts: unknown,
-            cb: Function
+            cb: ExecFileCallback
         ) => {
             cb(new Error('exited 1'), '', 'Unable to find a suitable output format');
         }) as unknown as typeof execFile);

--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -840,8 +840,31 @@ export class MetadataService {
                 throw new Error('Tagging resulted in invalid file size');
             }
 
-            fs.unlinkSync(filePath);
-            fs.renameSync(tempPath, filePath);
+            // Swap through a backup rather than unlinking the original first.
+            // The old order (unlink original -> rename temp into place) left no
+            // copy on disk if the rename failed — an SMB lock, an AV hold or a
+            // transient EPERM — and the catch below then removed the tagged temp
+            // via clean(), destroying both copies of the track. Mirrors the
+            // backup/restore swap already used by DownloadService.
+            const backupPath = `${filePath}.${uniqueSuffix}.bak`;
+            fs.renameSync(filePath, backupPath);
+            try {
+                fs.renameSync(tempPath, filePath);
+            } catch (e) {
+                try {
+                    fs.renameSync(backupPath, filePath);
+                } catch (restoreError) {
+                    const detail = restoreError instanceof Error ? restoreError.message : String(restoreError);
+                    logger.error(
+                        `Failed to restore original after tagging error (${detail}). The untagged original is preserved at: ${backupPath}`,
+                        'META'
+                    );
+                }
+                throw e;
+            }
+            // The swap already succeeded, so failing to remove the backup must
+            // not surface as a tagging error — callers delete the track on throw.
+            try { fs.unlinkSync(backupPath); } catch {}
         } catch (e) {
             clean();
             throw e instanceof Error ? e : new Error(String(e));


### PR DESCRIPTION
Follow-up to #58. While verifying that fix on a NAS-backed library I found three more paths where a track that had already been downloaded, MD5-verified and tagged still ended up deleted. All three need a filesystem that can fail *late* — an SMB share, a full disk, a read-only folder — which is why they don't show up in local testing.

## 1. A failed rename in `writeFlacTags` destroys both copies of the track

`writeFlacTags` finished with:

```ts
fs.unlinkSync(filePath);
fs.renameSync(tempPath, filePath);
```

The original is removed *before* the tagged temp file is moved into place. If that rename throws — an SMB lock (a media server scanning the folder), an AV hold, a transient `EPERM` — control reaches the `catch`, which calls `clean()`, and `clean()` deletes `tempPath`. The original is already gone, so **no copy of the track remains on disk** and the download is unrecoverable. A crash or power loss between the two calls loses the file the same way.

This now swaps through a backup and restores it when the move fails, mirroring the pattern already used in `DownloadService.replaceExistingFile`. If the restore itself fails, the backup path is logged rather than silently removed, so the user's audio is always recoverable. Removing the backup after a successful swap is deliberately non-fatal — the swap has already succeeded at that point, and throwing there would make callers treat a good file as a failed download.

## 2. A failed `.lrc` sidecar write deletes the finished track

In `downloadTrack` the sidecar write was unguarded, unlike the lyrics fetch and cover fetch around it:

```ts
if (lrcContent !== null) {
    const lrcPath = filePath.replace(/\.[^.]+$/, '.lrc');
    writeFileSync(lrcPath, lrcContent, 'utf8');   // throws -> outer catch deletes the FLAC
}
```

It sits inside the method's main `try`, and that method's `catch` runs `unlinkSync(cleanupPath)`. So on a read-only share or a full disk, failing to write a few KB of lyrics text discards a FLAC that had already downloaded, passed its MD5 check and been tagged. The queue then retries and repeats the whole cycle. Writing a sidecar can no longer take the track with it.

## 3. That deletion was completely silent

The `catch` deleted the file without logging, so a late-stage failure was indistinguishable from a download that never happened — the user sees a missing track and the log shows only the original error, nowhere near the file that was removed. It now logs the path and the reason before unlinking.

## Tests

Adds `src/services/metadata.file-swap.test.ts`, which runs against a **real temporary directory** — every existing test that touches this code mocks `fs` wholesale, which is why the swap logic has never been exercised. It covers the successful swap (original replaced, no temp files left behind), ffmpeg failure, and the regression above.

The swap test is a genuine regression test: on 5.3.4 it fails with `existsSync(track)` returning false — the track file is simply gone.

```
# on 5.3.4
× keeps the original when the tagged file cannot be moved into place
  AssertionError: expected false to be true

# with this change
✓ 3 passed
```

`tsc --noEmit` clean; full suite 216 passed (30 files).
