### PR TITLE
feat: disc placeholders so multi-disc releases can be split into folders

### DIFF
--- a/src/services/MetadataProcessor.ts
+++ b/src/services/MetadataProcessor.ts
@@ -26,6 +26,9 @@ export class MetadataProcessor {
             'META'
         );
 
+        const discNumber = Number(metadata.discNumber) || 1;
+        const totalDiscs = Number(metadata.totalDiscs) || 1;
+
         const data: Record<string, string> = {
             artist: metadata.artist || 'Unknown Artist',
             albumArtist: metadata.albumArtist || metadata.artist || 'Unknown Artist',
@@ -36,11 +39,23 @@ export class MetadataProcessor {
             format: qualityName,
             track_number: metadata.trackNumber?.toString().padStart(2, '0') || '01',
             tracknumber: metadata.trackNumber?.toString().padStart(2, '0') || '01',
-            track: metadata.trackNumber?.toString().padStart(2, '0') || '01'
+            track: metadata.trackNumber?.toString().padStart(2, '0') || '01',
+            disc: discNumber.toString(),
+            disc_number: discNumber.toString(),
+            discnumber: discNumber.toString(),
+            total_discs: totalDiscs.toString(),
+            totaldiscs: totalDiscs.toString(),
+            // Resolves to an empty string on single-disc releases so one folder
+            // template works for both: "{albumArtist}/{album}/{disc_folder}"
+            // yields "Artist/Album" for a single disc and "Artist/Album/CD2" for
+            // a multi-disc set, without stranding an empty path segment.
+            disc_folder: totalDiscs > 1 ? `CD${discNumber}` : ''
         };
 
         for (const [key, value] of Object.entries(data)) {
-            const sanitizedValue = this.sanitizeFilename(String(value));
+            // Deliberately-empty values must stay empty; sanitizeFilename maps
+            // falsy input to "Unknown", which would create an "Unknown" folder.
+            const sanitizedValue = value === '' ? '' : this.sanitizeFilename(String(value));
             const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
             const regex = new RegExp(`\\{${escapedKey}\\}`, 'gi');
 
@@ -55,7 +70,11 @@ export class MetadataProcessor {
     }
 
     buildFolderPath(metadata: Metadata, quality: number): string {
-        return this.applyTemplate(CONFIG.download.folderStructure, metadata, quality);
+        const rendered = this.applyTemplate(CONFIG.download.folderStructure, metadata, quality);
+        // A placeholder may render empty on purpose ({disc_folder} on a single-disc
+        // release), which would otherwise leave an empty segment and a stray
+        // separator in the path.
+        return rendered.split(/[/\\]/).filter(Boolean).join(path.sep);
     }
 
     buildFilename(metadata: Metadata, quality: number): string {

--- a/src/services/metadata-processor.test.ts
+++ b/src/services/metadata-processor.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
 import { MetadataProcessor } from './MetadataProcessor.js';
+import type { Metadata } from './metadata.js';
 
 vi.mock('../config.js', () => ({
     CONFIG: {
@@ -76,6 +78,71 @@ describe('MetadataProcessor', () => {
             const emptyMeta = {};
             const result = processor.applyTemplate('{artist} - {title}', emptyMeta as unknown as Record<string, unknown>, 27);
             expect(result).toBe('Unknown Artist - Unknown Title');
+        });
+    });
+
+    describe('multi-disc placeholders', () => {
+        const disc2 = {
+            artist: 'Metallica',
+            albumArtist: 'Metallica',
+            album: 'S&M',
+            title: 'Battery',
+            trackNumber: 10,
+            discNumber: 2,
+            totalDiscs: 2
+        };
+
+        const singleDisc = { ...disc2, discNumber: 1, totalDiscs: 1 };
+
+        it('exposes the disc number and total', () => {
+            const result = processor.applyTemplate(
+                '{disc_number}-{track_number} of {total_discs}',
+                disc2 as unknown as Record<string, unknown>,
+                27
+            );
+            expect(result).toBe('2-10 of 2');
+        });
+
+        it('renders {disc_folder} as CDn on a multi-disc release', () => {
+            const result = processor.applyTemplate(
+                '{disc_folder}',
+                disc2 as unknown as Record<string, unknown>,
+                27
+            );
+            expect(result).toBe('CD2');
+        });
+
+        it('renders {disc_folder} empty on a single-disc release', () => {
+            const result = processor.applyTemplate(
+                '{disc_folder}',
+                singleDisc as unknown as Record<string, unknown>,
+                27
+            );
+            expect(result).toBe('');
+        });
+
+        it('defaults to disc 1 of 1 when the release carries no disc data', () => {
+            const result = processor.applyTemplate(
+                '{disc_number}/{total_discs}[{disc_folder}]',
+                { title: 'T' } as unknown as Record<string, unknown>,
+                27
+            );
+            expect(result).toBe('1/1[]');
+        });
+
+        it('splits discs into subfolders without stranding a segment on single discs', async () => {
+            const { CONFIG } = await import('../config.js');
+            const original = CONFIG.download.folderStructure;
+            CONFIG.download.folderStructure = '{albumArtist}/{album}/{disc_folder}';
+
+            try {
+                expect(processor.buildFolderPath(disc2 as unknown as Metadata, 27))
+                    .toBe(path.join('Metallica', 'SandM', 'CD2'));
+                expect(processor.buildFolderPath(singleDisc as unknown as Metadata, 27))
+                    .toBe(path.join('Metallica', 'SandM'));
+            } finally {
+                CONFIG.download.folderStructure = original;
+            }
         });
     });
 


### PR DESCRIPTION
## Problem

Every disc of a multi-disc release lands in one flat folder, so track numbers collide. Downloading Metallica's *S&M* (2 discs, 21 tracks) produces:

```
Metallica/SandM/
  01. The Ecstasy Of Gold.flac      <- disc 1
  01. Nothing Else Matters.flac     <- disc 2
  02. The Call Of Ktulu.flac        <- disc 1
  02. Until It Sleeps.flac          <- disc 2
  03. Master Of Puppets.flac        <- disc 1
  03. For Whom The Bell Tolls.flac  <- disc 2
  ...
```

The discs interleave and the album can't be read in order from the filesystem. Worse, when two discs carry the same title at the same track position — common on deluxe editions that pair a studio and a live take, or on box sets — the second write silently replaces the first and one of the two tracks is lost.

The information needed to avoid this is already present end to end: Qobuz returns `media_number` / `media_count`, `extractMetadata` maps them to `discNumber` / `totalDiscs` (metadata.ts:190-191), and they are written into the files as `DISCNUMBER` / `DISCTOTAL` (metadata.ts:651-652). Only the filename templates couldn't see them — `applyTemplate` exposed artist, album, title, year, quality and track number, and nothing else.

## What this adds

| Placeholder | Renders |
|---|---|
| `{disc}`, `{disc_number}`, `{discnumber}` | disc number, unpadded — `2` |
| `{total_discs}`, `{totaldiscs}` | discs in the release — `2` |
| `{disc_folder}` | `CD2` when the release has more than one disc, empty otherwise |

`{disc_folder}` is the one that makes this usable as a single setting. With a folder template of:

```
{albumArtist}/{album}/{disc_folder}
```

a single-disc album still lands in `Artist/Album`, and a set lands in `Artist/Album/CD1`, `Artist/Album/CD2`. Users don't have to keep two templates around or accept a pointless `CD1` folder wrapping every normal album. Anyone who prefers flat folders can instead use `{disc_number}-{track_number}. {title}` as the file template and get `2-10. Battery.flac`.

## Two supporting changes this needs

- `applyTemplate` no longer passes an intentionally empty value through `sanitizeFilename`. That helper maps falsy input to `'Unknown'`, so an unused `{disc_folder}` would otherwise have created an `Unknown` folder for every single-disc album.
- `buildFolderPath` drops empty path segments, so the unused placeholder doesn't leave a stray separator in the middle of the path.

Both are scoped to the new behaviour: the placeholder keys are additive, and a template that doesn't reference them renders exactly as before.

## Not included

The settings UI has no hint listing the available placeholders, so this is only discoverable from the code. Adding one means touching every `i18n` locale file, which felt like a separate change — happy to follow up with it if you'd like.

## Tests

5 new cases in `metadata-processor.test.ts`: disc number and total, `{disc_folder}` on a multi-disc release, `{disc_folder}` on a single disc, the default when a release carries no disc data at all, and `buildFolderPath` producing `Metallica/SandM/CD2` versus `Metallica/SandM` from the same template.

`npm run lint` 0 errors, `tsc --noEmit` clean, full suite 218 passed (29 files).
