### PR TITLE
fix: Auto-Fix survives navigation, reports failures, and can be stopped

### DIFF
--- a/client/src/components/LibraryView.tsx
+++ b/client/src/components/LibraryView.tsx
@@ -4,6 +4,7 @@ import { useSocket } from '../contexts/SocketContext';
 import { useToast } from '../contexts/ToastContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Icons } from './Icons';
+import { useAutoFixStore, type AutoFixFile } from '../stores/autoFixStore';
 
 interface LibraryStats {
     totalFiles: number;
@@ -58,10 +59,7 @@ interface MissingMetadataFile {
     missingTags?: string[];
 }
 
-interface ProcessingFile extends MissingMetadataFile {
-    status: 'pending' | 'identifying' | 'found' | 'not_found' | 'applied';
-    result?: any;
-}
+type ProcessingFile = AutoFixFile;
 
 const QUALITY_LABELS: Record<number, string> = {
     5: 'MP3 320',
@@ -170,8 +168,11 @@ export const LibraryView: React.FC = () => {
 
     const [duplicates, setDuplicates] = useState<DuplicateGroup[]>([]);
     const [upgradeable, setUpgradeable] = useState<UpgradeableFile[]>([]);
-    const [missingMetadata, setMissingMetadata] = useState<ProcessingFile[]>([]);
-    const [processingMetadata, setProcessingMetadata] = useState(false);
+    const missingMetadata = useAutoFixStore((s) => s.files);
+    const setMissingMetadata = useAutoFixStore((s) => s.setFiles);
+    const processingMetadata = useAutoFixStore((s) => s.running);
+    const runAutoFix = useAutoFixStore((s) => s.run);
+    const stopAutoFix = useAutoFixStore((s) => s.stop);
     const [loading, setLoading] = useState(false);
     const [upgradingIds, setUpgradingIds] = useState<Set<string>>(new Set());
 
@@ -335,51 +336,17 @@ export const LibraryView: React.FC = () => {
     };
 
     const processMetadata = async () => {
-        if (processingMetadata) return;
-        setProcessingMetadata(true);
-        const files = [...missingMetadata];
+        await runAutoFix((summary) => {
+            const parts = [`${summary.applied} applied`];
+            if (summary.failed > 0) parts.push(`${summary.failed} failed`);
+            if (summary.notFound > 0) parts.push(`${summary.notFound} not found`);
 
-        for (let i = 0; i < files.length; i++) {
-            if (files[i].status === 'applied') continue;
-
-            files[i].status = 'identifying';
-            setMissingMetadata([...files]);
-
-
-            try {
-                const idRes = await smartFetch('/api/tools/identify', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ filePath: files[i].filePath })
-                });
-
-                if (idRes && idRes.ok) {
-                    const data = await idRes.json();
-                    files[i].result = data.data;
-                    files[i].status = 'found';
-                    setMissingMetadata([...files]);
-
-                    const applyRes = await smartFetch('/api/tools/apply-metadata', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ filePath: files[i].filePath, metadata: data.data })
-                    });
-
-                    if (applyRes && applyRes.ok) {
-                        files[i].status = 'applied';
-                        files[i].title = data.data.title;
-                        files[i].artist = data.data.artist;
-                    }
-                } else {
-                    files[i].status = 'not_found';
-                }
-            } catch (e) {
-                files[i].status = 'not_found';
-            }
-            setMissingMetadata([...files]);
-        }
-        setProcessingMetadata(false);
-        showToast('Metadata processing complete', 'success');
+            showToast(
+                `${summary.stopped ? 'Auto-Fix stopped' : 'Auto-Fix complete'}: ${parts.join(', ')}`,
+                summary.failed > 0 ? 'error' : 'success'
+            );
+            loadMissingMetadata();
+        });
     };
 
 
@@ -680,12 +647,13 @@ export const LibraryView: React.FC = () => {
                                 The following files are missing metadata, cover art, or lyrics. Click "Auto-Fix All" to identify and tag them using Smart Match.
                             </p>
                             <button
-                                className="btn primary"
-                                onClick={processMetadata}
-                                disabled={processingMetadata}
+                                className={`btn ${processingMetadata ? 'secondary' : 'primary'}`}
+                                onClick={processingMetadata ? stopAutoFix : processMetadata}
                                 style={{ display: 'flex', alignItems: 'center', gap: '6px' }}
                             >
-                                {processingMetadata ? 'Processing...' : <><Icons.Check width={14} height={14} /> Auto-Fix All ({missingMetadata.length})</>}
+                                {processingMetadata
+                                    ? `Stop (${missingMetadata.filter(f => f.status === 'applied' || f.status === 'failed' || f.status === 'not_found').length}/${missingMetadata.length})`
+                                    : <><Icons.Check width={14} height={14} /> Auto-Fix All ({missingMetadata.length})</>}
                             </button>
                         </div>
                     )}
@@ -715,14 +683,18 @@ export const LibraryView: React.FC = () => {
                                             <td>{renderMissingTags(file)}</td>
                                             <td>
                                                 <span className={`badge ${file.status === 'applied' ? 'success' :
-                                                    file.status === 'not_found' ? 'error' :
+                                                    (file.status === 'not_found' || file.status === 'failed') ? 'error' :
                                                         file.status === 'identifying' ? 'info' : 'warning'
                                                     }`}>
                                                     {getStatusLabel(file)}
                                                 </span>
                                             </td>
                                             <td>
-                                                {file.result ? (
+                                                {file.error ? (
+                                                    <span style={{ color: 'var(--danger)', fontSize: '0.85em' }} title={file.error}>
+                                                        {file.error}
+                                                    </span>
+                                                ) : file.result ? (
                                                     <div className="track-info">
                                                         <span style={{ fontWeight: 600 }}>{file.result.title}</span>
                                                         <span style={{ opacity: 0.8 }}> - {file.result.artist}</span>

--- a/client/src/stores/__tests__/autoFixStore.test.ts
+++ b/client/src/stores/__tests__/autoFixStore.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useAutoFixStore, type AutoFixFile } from '../autoFixStore';
+import { smartFetch } from '../../utils/api';
+
+vi.mock('../../utils/api', () => ({ smartFetch: vi.fn() }));
+
+const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+const fail = (status: number, error: string) =>
+    ({ ok: false, status, json: async () => ({ error }) }) as unknown as Response;
+
+const file = (filePath: string): AutoFixFile => ({
+    filePath,
+    title: 'T',
+    artist: 'A',
+    status: 'pending'
+});
+
+const reset = (files: AutoFixFile[]) =>
+    useAutoFixStore.setState({ files, running: false, stopRequested: false });
+
+describe('autoFixStore', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        reset([]);
+    });
+
+    it('marks a file failed and keeps the reason when the write is rejected', async () => {
+        reset([file('/music/a.flac')]);
+        vi.mocked(smartFetch)
+            .mockResolvedValueOnce(ok({ data: { title: 'Real', artist: 'Band' } }))
+            .mockResolvedValueOnce(fail(500, 'EACCES: permission denied'));
+
+        const done = vi.fn();
+        await useAutoFixStore.getState().run(done);
+
+        const [result] = useAutoFixStore.getState().files;
+        expect(result?.status).toBe('failed');
+        expect(result?.error).toBe('EACCES: permission denied');
+        expect(done).toHaveBeenCalledWith(
+            expect.objectContaining({ applied: 0, failed: 1, stopped: false })
+        );
+    });
+
+    it('reports applied files in the summary', async () => {
+        reset([file('/music/a.flac')]);
+        vi.mocked(smartFetch)
+            .mockResolvedValueOnce(ok({ data: { title: 'Real', artist: 'Band' } }))
+            .mockResolvedValueOnce(ok({ success: true }));
+
+        const done = vi.fn();
+        await useAutoFixStore.getState().run(done);
+
+        expect(useAutoFixStore.getState().files[0]?.status).toBe('applied');
+        expect(done).toHaveBeenCalledWith(
+            expect.objectContaining({ applied: 1, failed: 0, notFound: 0 })
+        );
+    });
+
+    it('ignores a list reload while a run is in progress', async () => {
+        reset([file('/music/a.flac')]);
+        useAutoFixStore.setState({ running: true });
+
+        // A tab switch refetches the list; accepting it mid-run would wipe the
+        // live per-file progress the loop is writing.
+        useAutoFixStore.getState().setFiles([file('/music/other.flac')]);
+
+        expect(useAutoFixStore.getState().files[0]?.filePath).toBe('/music/a.flac');
+    });
+
+    it('stops before the next file once stop is requested', async () => {
+        reset([file('/music/a.flac'), file('/music/b.flac')]);
+        vi.mocked(smartFetch).mockImplementation(async (url: string) => {
+            if (url.includes('identify')) return ok({ data: { title: 'Real', artist: 'Band' } });
+            useAutoFixStore.getState().stop();
+            return ok({ success: true });
+        });
+
+        const done = vi.fn();
+        await useAutoFixStore.getState().run(done);
+
+        const files = useAutoFixStore.getState().files;
+        expect(files[0]?.status).toBe('applied');
+        expect(files[1]?.status).toBe('pending');
+        expect(done).toHaveBeenCalledWith(expect.objectContaining({ applied: 1, stopped: true }));
+        expect(useAutoFixStore.getState().running).toBe(false);
+    });
+
+    it('refuses to start a second concurrent run', async () => {
+        reset([file('/music/a.flac')]);
+        useAutoFixStore.setState({ running: true });
+
+        await useAutoFixStore.getState().run();
+
+        expect(smartFetch).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/stores/autoFixStore.ts
+++ b/client/src/stores/autoFixStore.ts
@@ -1,0 +1,134 @@
+import { create } from 'zustand';
+import { smartFetch } from '../utils/api';
+
+export interface AutoFixFile {
+    filePath: string;
+    title: string;
+    artist: string;
+    album?: string;
+    missingTags?: string[];
+    status: 'pending' | 'identifying' | 'found' | 'not_found' | 'applied' | 'failed';
+    error?: string;
+    result?: any;
+}
+
+export interface AutoFixSummary {
+    applied: number;
+    failed: number;
+    notFound: number;
+    stopped: boolean;
+}
+
+interface AutoFixState {
+    files: AutoFixFile[];
+    running: boolean;
+    stopRequested: boolean;
+    setFiles: (files: AutoFixFile[]) => void;
+    stop: () => void;
+    run: (onDone?: (summary: AutoFixSummary) => void) => Promise<void>;
+}
+
+const readError = async (res: Response | null): Promise<string> => {
+    if (!res) return 'Request failed';
+    try {
+        const body = await res.json();
+        return String(body?.error || `HTTP ${res.status}`);
+    } catch {
+        return `HTTP ${res.status}`;
+    }
+};
+
+/**
+ * Auto-Fix runs here rather than inside LibraryView so it survives navigation.
+ * As component state, the loop kept running after the view unmounted while its
+ * "running" flag was destroyed with the component -- so returning to the tab
+ * showed an idle button over a job that was still writing files, and pressing it
+ * again started a second concurrent pass over the same paths.
+ */
+export const useAutoFixStore = create<AutoFixState>((set, get) => ({
+    files: [],
+    running: false,
+    stopRequested: false,
+
+    // Refusing writes mid-run keeps a tab switch (which refetches the list) from
+    // discarding the live per-file progress.
+    setFiles: (files) => {
+        if (get().running) return;
+        set({ files });
+    },
+
+    stop: () => set({ stopRequested: true }),
+
+    run: async (onDone) => {
+        if (get().running) return;
+        set({ running: true, stopRequested: false });
+
+        const files = get().files.map((f) => ({ ...f }));
+        const summary: AutoFixSummary = { applied: 0, failed: 0, notFound: 0, stopped: false };
+        const commit = () => set({ files: files.map((f) => ({ ...f })) });
+
+        for (let i = 0; i < files.length; i++) {
+            if (get().stopRequested) {
+                summary.stopped = true;
+                break;
+            }
+
+            const file = files[i];
+            if (!file || file.status === 'applied') continue;
+
+            file.status = 'identifying';
+            file.error = undefined;
+            commit();
+
+            try {
+                const idRes = await smartFetch('/api/tools/identify', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ filePath: file.filePath })
+                });
+
+                if (!idRes || !idRes.ok) {
+                    file.status = 'not_found';
+                    file.error = await readError(idRes);
+                    summary.notFound++;
+                    commit();
+                    continue;
+                }
+
+                const data = await idRes.json();
+                file.result = data.data;
+                file.status = 'found';
+                commit();
+
+                const applyRes = await smartFetch('/api/tools/apply-metadata', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ filePath: file.filePath, metadata: data.data })
+                });
+
+                if (applyRes && applyRes.ok) {
+                    file.status = 'applied';
+                    file.title = data.data?.title ?? file.title;
+                    file.artist = data.data?.artist ?? file.artist;
+                    summary.applied++;
+                } else {
+                    // A failed write -- read-only share, locked file, bad path --
+                    // used to be dropped here, leaving the row looking untouched
+                    // and the run still reporting success at the end.
+                    file.status = 'failed';
+                    file.error = await readError(applyRes);
+                    summary.failed++;
+                }
+            } catch (e) {
+                file.status = 'failed';
+                file.error = e instanceof Error ? e.message : String(e);
+                summary.failed++;
+            }
+
+            commit();
+        }
+
+        set({ running: false, stopRequested: false });
+        onDone?.(summary);
+    }
+}));

--- a/src/services/dashboard/routers/library.routes.ts
+++ b/src/services/dashboard/routers/library.routes.ts
@@ -4,6 +4,7 @@ import { libraryScannerService } from '../../library-scanner/index.js';
 import { libraryStatisticsService } from '../../LibraryStatisticsService.js';
 import { CONFIG } from '../../../config.js';
 import { formatConverterService } from '../../FormatConverterService.js';
+import { logger } from '../../../utils/logger.js';
 
 const router = Router();
 
@@ -185,6 +186,10 @@ router.post('/metadata/edit', async (req: Request, res: Response) => {
         await metadataService.writeMetadata(filePath, targetMeta as any, 0, lyrics, coverBuffer);
         res.json({ success: true });
     } catch (error: unknown) {
+        logger.error(
+            `Failed to write metadata to ${req.body?.filePath}: ${(error as Error).message}`,
+            'LIBRARY'
+        );
         res.status(500).json({ error: (error as Error).message });
     }
 });

--- a/src/services/dashboard/routers/tools.routes.ts
+++ b/src/services/dashboard/routers/tools.routes.ts
@@ -201,6 +201,13 @@ router.post('/apply-metadata', async (req: Request, res: Response) => {
         await metadataService.writeMetadata(filePath as string, targetMeta as any, 0, lyrics as any, coverBuffer);
         res.json({ success: true });
     } catch (error: unknown) {
+        // Log as well as answer the client: a tagging failure that only travels
+        // back over HTTP leaves no trace in the logs, so a run that silently
+        // wrote nothing is indistinguishable from one that worked.
+        logger.error(
+            `Failed to apply metadata to ${req.body?.filePath}: ${(error as Error).message}`,
+            'TOOLS'
+        );
         res.status(500).json({ error: (error as Error).message });
     }
 });


### PR DESCRIPTION
## Problem

Auto-Fix runs as a plain async loop inside `LibraryView`, so the job and the component that owns it have different lifetimes. Leaving the tab unmounts the view and destroys `processingMetadata`, but nothing stops the loop — it keeps issuing `/identify` and `/apply-metadata` calls against the files it captured.

Reproduced on a 125-file library: start Auto-Fix, switch to System Logs, come back. The button reads **"Auto-Fix All (125)"** and is clickable while the server log is still writing tags. Three consequences:

- The idle-looking button starts a **second concurrent pass** over the same paths, so two loops tag the same files at once.
- The remount refetches the list (`useEffect` on `activeTab === 'metadata'` → `loadMissingMetadata`), replacing the array the loop is writing into, so all per-file progress is discarded.
- There is no way to stop a run at all — the only control is the button, which is disabled while it is active. The library scan next to it does have a Stop button.

Separately, the non-ok branch of the apply request did nothing:

```ts
if (applyRes && applyRes.ok) {
    files[i].status = 'applied';
    ...
}   // <- no else: a 500 leaves the row untouched and the body unread
```

so a run where every write failed (read-only share, locked files, a permissions problem on a NAS) looked identical to a clean one, and still finished with an unconditional `showToast('Metadata processing complete', 'success')`. Neither `/api/tools/apply-metadata` nor `/api/library/metadata/edit` logged the failure either — it only travelled back over HTTP, so nothing appeared in the logs.

## Changes

The run moves into a zustand store, `client/src/stores/autoFixStore.ts`, so it outlives the view:

- `setFiles` is ignored while a run is active, so the tab-switch refetch can no longer wipe live progress.
- The button becomes **Stop** while running and shows `Stop (47/125)`; the loop checks the flag between files.
- `run()` refuses to start when one is already in flight, so the second-pass case is impossible even if the UI gets out of sync.
- A rejected apply marks the file `failed` and keeps the server's message, rendered in the Result column.
- The closing toast reports `N applied, M failed, K not found` and is an error toast when anything failed.

Server side, both tagging routes now `logger.error` before answering, so a failed write reaches the log file.

## Tests

5 new cases in `client/src/stores/__tests__/autoFixStore.test.ts`: a rejected write (status + preserved reason + summary), a successful apply, the reload guard mid-run, stop-between-files, and the refusal to start a second concurrent run.

Backend 218 passed, client 76 passed, both packages lint- and type-clean, client builds.

## Note

This is UI-facing, so a maintainer eye on the wording and button styling would be welcome — I kept both minimal and reused existing classes rather than introducing new ones.
