### PR TITLE
fix: confine caller-supplied file paths to the managed library directories

### DIFF
--- a/src/services/dashboard/index.ts
+++ b/src/services/dashboard/index.ts
@@ -304,9 +304,33 @@ export class DashboardService {
         });
     }
 
+    /** Loopback binds are reachable from this machine alone. */
+    private static isLoopbackHost(host: string): boolean {
+        const normalized = host.trim().toLowerCase().replace(/^\[|\]$/g, '');
+        return (
+            normalized === 'localhost' ||
+            normalized === '::1' ||
+            normalized === '127.0.0.1' ||
+            normalized.startsWith('127.')
+        );
+    }
+
     public start(port?: number): void {
         if (port !== undefined) this.port = port;
-        const host = CONFIG.dashboard.host || '127.0.0.1';
+        let host = CONFIG.dashboard.host || '127.0.0.1';
+
+        // Serving a network interface with no password exposes every API route --
+        // including the ones that delete and overwrite library files -- to anyone
+        // who can reach the port. Fall back to loopback rather than coming up wide
+        // open; setting a password restores the requested bind.
+        if (!DashboardService.isLoopbackHost(host) && !CONFIG.dashboard.password) {
+            logger.error(
+                `Refusing to serve ${host}:${this.port} without a dashboard password — ` +
+                    'binding to 127.0.0.1 instead. Set a dashboard password to expose it.',
+                'SECURITY'
+            );
+            host = '127.0.0.1';
+        }
 
         this.httpServer.once('error', (error) => {
             const message = error instanceof Error ? error.message : String(error);

--- a/src/services/dashboard/routers/library.routes.ts
+++ b/src/services/dashboard/routers/library.routes.ts
@@ -5,6 +5,7 @@ import { libraryStatisticsService } from '../../LibraryStatisticsService.js';
 import { CONFIG } from '../../../config.js';
 import { formatConverterService } from '../../FormatConverterService.js';
 import { logger } from '../../../utils/logger.js';
+import { isPathWithinManagedRoots } from '../../../utils/paths.js';
 
 const router = Router();
 
@@ -113,6 +114,12 @@ router.post('/metadata/edit', async (req: Request, res: Response) => {
             return;
         }
 
+        if (!isPathWithinManagedRoots(filePath)) {
+            logger.warn(`Refused metadata write outside the library: ${filePath}`, 'LIBRARY');
+            res.status(403).json({ error: 'Path is outside the library directory' });
+            return;
+        }
+
         const { default: MetadataService } = await import('../../metadata.js');
         const metadataService = new MetadataService();
 
@@ -200,6 +207,12 @@ router.delete('/file', async (req: Request, res: Response) => {
 
         if (!filePath) {
             res.status(400).json({ error: 'filePath is required' });
+            return;
+        }
+
+        if (!isPathWithinManagedRoots(filePath)) {
+            logger.warn(`Refused delete outside the library: ${filePath}`, 'LIBRARY');
+            res.status(403).json({ error: 'Path is outside the library directory' });
             return;
         }
 

--- a/src/services/dashboard/routers/tools.routes.ts
+++ b/src/services/dashboard/routers/tools.routes.ts
@@ -3,6 +3,7 @@ import qobuzApi from '../../../api/qobuz.js';
 import path from 'path';
 import axios from 'axios';
 import { logger } from '../../../utils/logger.js';
+import { isPathWithinManagedRoots } from '../../../utils/paths.js';
 import { CONFIG } from '../../../config.js';
 import { databaseService } from '../../database/index.js';
 import {
@@ -89,6 +90,11 @@ router.post('/identify', async (req: Request, res: Response) => {
         const { filePath } = req.body;
         if (!filePath) return res.status(400).json({ error: 'filePath is required' });
 
+        if (!isPathWithinManagedRoots(filePath)) {
+            logger.warn(`Refused identify outside the library: ${filePath}`, 'TOOLS');
+            return res.status(403).json({ error: 'Path is outside the library directory' });
+        }
+
         const filename = path.basename(filePath as string, path.extname(filePath as string));
         const parts = (filePath as string).split(path.sep);
         
@@ -158,6 +164,11 @@ router.post('/apply-metadata', async (req: Request, res: Response) => {
         const { filePath, metadata } = req.body;
         if (!filePath || !metadata) {
             return res.status(400).json({ error: 'filePath and metadata are required' });
+        }
+
+        if (!isPathWithinManagedRoots(filePath)) {
+            logger.warn(`Refused metadata write outside the library: ${filePath}`, 'TOOLS');
+            return res.status(403).json({ error: 'Path is outside the library directory' });
         }
 
         const { default: MetadataService } = await import('../../metadata.js');

--- a/src/utils/paths.test.ts
+++ b/src/utils/paths.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const CONFIG = {
+    download: { outputDir: '' },
+    export: { outputDir: '' }
+};
+
+vi.mock('../config.js', () => ({ CONFIG }));
+
+const { isPathWithinManagedRoots, getManagedRoots } = await import('./paths.js');
+
+describe('isPathWithinManagedRoots', () => {
+    let root: string;
+    let outside: string;
+
+    beforeEach(() => {
+        root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'qbz-lib-')));
+        outside = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'qbz-out-')));
+        CONFIG.download.outputDir = root;
+        CONFIG.export.outputDir = '';
+    });
+
+    afterEach(() => {
+        fs.rmSync(root, { recursive: true, force: true });
+        fs.rmSync(outside, { recursive: true, force: true });
+    });
+
+    it('accepts a file inside the library', () => {
+        const file = path.join(root, 'Artist', 'Album', '01. Track.flac');
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, 'x');
+        expect(isPathWithinManagedRoots(file)).toBe(true);
+    });
+
+    it('accepts a not-yet-created file inside the library', () => {
+        expect(isPathWithinManagedRoots(path.join(root, 'new', 'file.flac'))).toBe(true);
+    });
+
+    it('rejects an arbitrary absolute path', () => {
+        // The reported attack: DELETE /api/library/file with someone's private key.
+        expect(isPathWithinManagedRoots(path.join(os.homedir(), '.ssh', 'id_rsa'))).toBe(false);
+        expect(isPathWithinManagedRoots('/etc/passwd')).toBe(false);
+    });
+
+    it('rejects traversal that climbs out of the library', () => {
+        expect(isPathWithinManagedRoots(path.join(root, '..', '..', 'etc', 'passwd'))).toBe(false);
+    });
+
+    it('rejects a sibling directory sharing the root prefix', () => {
+        expect(isPathWithinManagedRoots(`${root}-backup/track.flac`)).toBe(false);
+    });
+
+    it('rejects a symlink inside the library that points outside it', () => {
+        const secret = path.join(outside, 'secret.txt');
+        fs.writeFileSync(secret, 'x');
+        const link = path.join(root, 'escape.flac');
+        fs.symlinkSync(secret, link);
+
+        expect(isPathWithinManagedRoots(link)).toBe(false);
+    });
+
+    it('rejects empty and non-string input', () => {
+        expect(isPathWithinManagedRoots('')).toBe(false);
+        expect(isPathWithinManagedRoots('   ')).toBe(false);
+        expect(isPathWithinManagedRoots(undefined)).toBe(false);
+        expect(isPathWithinManagedRoots(null)).toBe(false);
+        expect(isPathWithinManagedRoots(42)).toBe(false);
+    });
+
+    it('also accepts files under the export directory when one is configured', () => {
+        CONFIG.export.outputDir = outside;
+        expect(getManagedRoots()).toHaveLength(2);
+        expect(isPathWithinManagedRoots(path.join(outside, 'converted.mp3'))).toBe(true);
+    });
+});

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import { CONFIG } from '../config.js';
+
+/**
+ * Path containment for routes that act on a caller-supplied file path.
+ *
+ * The library routes take `filePath` straight from the request body and delete
+ * or overwrite it. That is only safe while the dashboard is bound to loopback;
+ * exposed on a network (a container, or DASHBOARD_HOST set to 0.0.0.0) it lets
+ * any caller name any path the process can reach. These helpers keep such a
+ * request inside the directories the app actually manages.
+ */
+
+/**
+ * Resolve a path with symlinks followed, so a link inside the library cannot be
+ * used to reach outside it. Falls back to the closest existing ancestor when the
+ * target itself does not exist yet.
+ */
+const resolveReal = (target: string): string => {
+    const resolved = path.resolve(target);
+    try {
+        return fs.realpathSync(resolved);
+    } catch {
+        try {
+            return path.join(fs.realpathSync(path.dirname(resolved)), path.basename(resolved));
+        } catch {
+            return resolved;
+        }
+    }
+};
+
+/** Directories the app owns: the download/library root, plus the export dir. */
+export const getManagedRoots = (): string[] =>
+    [CONFIG.download.outputDir, CONFIG.export?.outputDir]
+        .filter((root): root is string => typeof root === 'string' && root.trim().length > 0)
+        .map(resolveReal);
+
+/**
+ * True when `filePath` resolves inside a directory the app manages. The
+ * separator check stops a sibling such as `/music-backup` from matching the
+ * root `/music`.
+ */
+export const isPathWithinManagedRoots = (filePath: unknown): boolean => {
+    if (typeof filePath !== 'string' || !filePath.trim()) return false;
+
+    const target = resolveReal(filePath);
+    return getManagedRoots().some(
+        (root) => target === root || target.startsWith(root + path.sep)
+    );
+};


### PR DESCRIPTION
## Problem

Four routes take a `filePath` straight from the request body and act on it with no validation of where it points:

| Route | Effect |
|---|---|
| `DELETE /api/library/file` | `libraryScannerService.deleteFile()` → `fs.unlinkSync(filePath)` |
| `POST /api/library/metadata/edit` | `writeMetadata()` rewrites the file |
| `POST /api/tools/apply-metadata` | `writeMetadata()` rewrites the file |
| `POST /api/tools/identify` | reads the path |

So `DELETE /api/library/file` with `{"filePath": "/home/user/.ssh/id_rsa"}` deletes it.

This is currently masked by two things: the dashboard binds `127.0.0.1` by default, and the desktop build sets `QBZ_DESKTOP=1`, which short-circuits the auth middleware entirely (`index.ts:125`). But `DASHBOARD_HOST` is a normal setting, and the moment it points at a real interface — a server install, or a container with the music library mounted — every one of those routes is reachable unauthenticated by anything on the network. The password also defaults to empty, so nothing prompts the operator to set one before that happens.

## Changes

**Path containment.** New `src/utils/paths.ts` exposes `isPathWithinManagedRoots()`, which confines a caller-supplied path to the directories the app actually manages (`CONFIG.download.outputDir`, plus `CONFIG.export.outputDir` when configured). All four routes reject anything outside with `403` and a log line.

It resolves through symlinks rather than comparing strings, so a link planted inside the library cannot be used to step outside it, and it compares against `root + path.sep` so a sibling like `/music-backup` does not match the root `/music`. Paths that do not exist yet resolve via their closest existing ancestor, which keeps write targets working without opening a hole through a symlinked parent.

**Startup guard.** `DashboardService.start()` now refuses to bind a non-loopback host when no dashboard password is set: it logs the reason at `SECURITY` and binds `127.0.0.1` instead. Setting a password restores the requested bind. This is the difference between a misconfigured server install being unreachable and it being wide open.

Nothing changes for the default desktop case — loopback with no password behaves exactly as before.

## Not included

`/api/stream/` and `/api/preview/` remain in the middleware's `excludedRoutes`, so they stay reachable even when a password is set. That one is not a server-side one-liner: `Player.tsx:218` assigns `/api/stream/<id>` directly to an `<audio>` element's `src`, and a media element cannot carry the `x-password` header `smartFetch` uses — which is presumably why the exclusion exists. Closing it means passing the password as a query parameter (the middleware already accepts `req.query.pw`) and changing how the client builds those URLs. Happy to do that as a follow-up; it seemed wrong to bundle a playback change into a path-validation PR.

## Tests

`src/utils/paths.test.ts`, 8 cases against a real temporary directory: a file inside the library, a not-yet-created file inside it, an arbitrary absolute path (`~/.ssh/id_rsa`, `/etc/passwd`), `../` traversal out of the root, a sibling directory sharing the root's prefix, a symlink inside the library pointing outside it, empty/non-string input, and the export directory when one is configured.

`npm test` 229 passed (31 files), `tsc --noEmit` clean, `npm run lint` 0 errors.
