### PR TITLE
fix: bound a stalled transfer and stop retrying unresolvable queue items

### DIFF
--- a/src/services/DownloadEngine.ts
+++ b/src/services/DownloadEngine.ts
@@ -7,6 +7,14 @@ import { CONFIG } from '../config.js';
 import { resumeService } from './batch.js';
 import { Metadata } from './metadata.js';
 
+/**
+ * A transfer that goes this long without delivering a byte is treated as dead.
+ * Without it a silently dropped socket never emits 'error', 'aborted' or 'end',
+ * so the download promise never settles: the track hangs, the album's Promise.all
+ * never resolves, and the queue item holds its slot in 'downloading' forever.
+ */
+const STREAM_IDLE_TIMEOUT_MS = 60_000;
+
 export interface DownloadProgress {
     phase: 'download_start' | 'download' | 'lyrics' | 'cover' | 'tagging' | 'verifying';
     loaded: number;
@@ -121,17 +129,40 @@ export class DownloadEngine {
         try {
             await new Promise<void>((resolve, reject) => {
                 let settled = false;
+                let idleTimer: NodeJS.Timeout | null = null;
+
+                const clearIdleTimer = () => {
+                    if (idleTimer) {
+                        clearTimeout(idleTimer);
+                        idleTimer = null;
+                    }
+                };
+                const armIdleTimer = () => {
+                    clearIdleTimer();
+                    idleTimer = setTimeout(() => {
+                        fail(
+                            new Error(
+                                `Stream stalled: no data received for ${STREAM_IDLE_TIMEOUT_MS / 1000}s`
+                            )
+                        );
+                    }, STREAM_IDLE_TIMEOUT_MS);
+                };
+
                 const fail = (error: unknown) => {
                     if (settled) return;
                     settled = true;
+                    clearIdleTimer();
                     reject(normalizeDownloadError(error, downloaded, effectiveTotalLength));
                 };
                 const done = () => {
                     if (settled) return;
                     settled = true;
+                    clearIdleTimer();
                     resolve();
                 };
                 const onData = (chunk: Buffer) => {
+                    armIdleTimer();
+
                     if (isCancelled && isCancelled()) {
                         fail(new Error('Cancelled by user'));
                         return;
@@ -170,6 +201,10 @@ export class DownloadEngine {
                 writer.on('error', fail);
                 response.data.on('aborted', () => fail(new Error('aborted')));
                 response.data.on('error', fail);
+
+                // Start the clock before the first byte: a connection that opens
+                // and then says nothing is just as dead as one that stops midway.
+                armIdleTimer();
             });
         } finally {
             if (!writer.closed) {

--- a/src/services/download-engine.test.ts
+++ b/src/services/download-engine.test.ts
@@ -199,4 +199,91 @@ describe('DownloadEngine', () => {
             expect.objectContaining({ headers: { 'Range': 'bytes=500-' } })
         );
     });
+
+    describe('stalled transfers', () => {
+        const makeStream = () => {
+            const stream = new EventEmitter();
+            (stream as unknown as Record<string, unknown>).pipe = vi.fn().mockReturnThis();
+            (stream as unknown as Record<string, unknown>).destroy = vi.fn();
+            return stream;
+        };
+
+        // Settle into a value either way so the promise is never left unhandled
+        // while fake timers are driving the clock.
+        const begin = (stream: EventEmitter) => {
+            vi.mocked(network.downloadFile).mockResolvedValue({
+                status: 200,
+                headers: { 'content-length': '1000' },
+                data: stream
+            } as unknown as AxiosResponse);
+
+            return engine
+                .download('url', 'path', 'id', { title: 'T' } as unknown as Metadata, 1000, 27)
+                .then(
+                    (ok) => ({ ok, err: undefined as Error | undefined }),
+                    (err: Error) => ({ ok: undefined, err })
+                );
+        };
+
+        // A socket that goes quiet emits no 'end', 'error' or 'aborted', so before
+        // the idle timeout this promise never settled: the track hung forever and
+        // its queue item held a slot in 'downloading' indefinitely.
+        it('rejects a stream that stops delivering data', async () => {
+            vi.useFakeTimers();
+            try {
+                const stream = makeStream();
+                const settled = begin(stream);
+                await vi.advanceTimersByTimeAsync(0);
+
+                stream.emit('data', Buffer.alloc(100));
+                await vi.advanceTimersByTimeAsync(61_000);
+
+                const { err } = await settled;
+                expect(err).toBeInstanceOf(Error);
+                expect(err?.message).toMatch(/stalled/i);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('rejects a connection that never delivers a first byte', async () => {
+            vi.useFakeTimers();
+            try {
+                const settled = begin(makeStream());
+                await vi.advanceTimersByTimeAsync(0);
+
+                await vi.advanceTimersByTimeAsync(61_000);
+
+                const { err } = await settled;
+                expect(err?.message).toMatch(/stalled/i);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('keeps a slow but progressing transfer alive', async () => {
+            vi.useFakeTimers();
+            try {
+                const stream = makeStream();
+                const settled = begin(stream);
+                await vi.advanceTimersByTimeAsync(0);
+
+                const writer = vi.mocked(fs.createWriteStream).mock.results.at(-1)!.value;
+
+                // A chunk every 50s stays under the 60s limit, so the timer re-arms.
+                for (let i = 0; i < 4; i++) {
+                    stream.emit('data', Buffer.alloc(250));
+                    await vi.advanceTimersByTimeAsync(50_000);
+                }
+                writer.emit('finish');
+                await vi.advanceTimersByTimeAsync(0);
+
+                const { ok, err } = await settled;
+                expect(err).toBeUndefined();
+                expect(ok?.size).toBe(1000);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
 });

--- a/src/services/queue-processor.ts
+++ b/src/services/queue-processor.ts
@@ -8,6 +8,9 @@ import { QueueItem } from './queue/types.js';
 import { CONFIG } from '../config.js';
 import { notifyDownloadComplete, notifyDownloadError } from './notifications.js';
 
+/** Hydration passes to spend on one queue item before treating it as unresolvable. */
+const MAX_HYDRATION_ATTEMPTS = 3;
+
 enum ErrorCategory {
     NETWORK = 'network',
     AUTH = 'auth',
@@ -97,6 +100,8 @@ export class QueueProcessor {
     private runningTasks: Set<string> = new Set();
     private isHydrationRunning: boolean = false;
     private isStarted: boolean = false;
+    /** Hydration attempts per content id, so an unresolvable item is dropped. */
+    private hydrationAttempts: Map<string | number, number> = new Map();
 
     constructor() {
         const lyricsProvider = new LyricsProvider();
@@ -126,7 +131,9 @@ export class QueueProcessor {
             try {
                 const pendingItems = downloadQueue.getPendingItems();
                 const itemsToHydrate = pendingItems.filter(
-                    (item) => !item.title || item.title === `${item.type}: ${item.contentId}`
+                    (item) =>
+                        (!item.title || item.title === `${item.type}: ${item.contentId}`) &&
+                        (this.hydrationAttempts.get(item.contentId) ?? 0) < MAX_HYDRATION_ATTEMPTS
                 );
 
                 for (const item of itemsToHydrate) {
@@ -172,12 +179,27 @@ export class QueueProcessor {
                             );
                         }
 
+                        this.hydrationAttempts.delete(item.contentId);
                         await sleep(200);
                     } catch (e: unknown) {
                         const err = e as Error;
-                        logger.debug(
-                            `Failed to hydrate metadata for ${item.contentId}: ${err.message}`
-                        );
+                        // Count the failure and stop after a few tries. Content that
+                        // has been pulled from Qobuz can never resolve, and because
+                        // the item keeps its empty title it matched the filter again
+                        // on every 5s pass — retrying the same dead id forever.
+                        const attempts = (this.hydrationAttempts.get(item.contentId) ?? 0) + 1;
+                        this.hydrationAttempts.set(item.contentId, attempts);
+
+                        if (attempts >= MAX_HYDRATION_ATTEMPTS) {
+                            logger.warn(
+                                `Giving up on metadata for ${item.type} ${item.contentId} after ${attempts} attempts: ${err.message}`,
+                                'QUEUE'
+                            );
+                        } else {
+                            logger.debug(
+                                `Failed to hydrate metadata for ${item.contentId}: ${err.message}`
+                            );
+                        }
                     }
                 }
             } catch (error) {


### PR DESCRIPTION
Two faults seen together on a long-running instance: the queue stopped making progress while the log filled with the same two lines every five seconds, forever.

## 1. A stalled transfer wedges the queue permanently

`DownloadEngine.download()` settles its promise on exactly four events — `writer.finish`, `writer.error`, `response.data.aborted` and `response.data.error` — and nothing bounds how long it waits for them. `downloadFile()` sets no `timeout`, and axios' `timeout` would not help anyway: it covers the response headers, not the body stream.

So when a socket goes quiet without emitting anything — a half-open connection, a CDN that stops sending mid-file — the promise never settles. The track hangs, the album's `Promise.all` never resolves, and the queue item stays `downloading` forever. Since the processor runs a fixed number of items at once, two of those exhaust every slot and nothing pending can ever start again. Observed exactly that: two items stuck in `downloading`, two stuck in `pending`, no progress.

This is not hypothetical on flaky upstreams — the same account produced `Qobuz stream aborted after 31525963 of 96190720 bytes` on a neighbouring track, which is the case that *does* emit `aborted`. The silent variant is the one that hangs.

Adds a 60s idle timeout: the timer is armed before the first byte, re-armed on every chunk, and cleared when the promise settles. A dead transfer now fails with `Stream stalled: no data received for 60s` and flows through the existing retry path instead of pinning a slot.

## 2. Metadata hydration retries unresolvable items forever

`startMetadataHydration()` loops every 5s over pending items whose title is empty, and on failure does only:

```ts
} catch (e) {
    logger.debug(`Failed to hydrate metadata for ${item.contentId}: ${err.message}`);
}
```

The title is never set and nothing records the failure, so the same item matches the filter again on the next pass. For content that has been pulled from Qobuz (`No result matching given argument`) it can never succeed, so it retries that dead id every five seconds for as long as the process runs — two such items produced tens of thousands of log lines and API calls in a single session.

Adds a per-content-id attempt counter, capped at 3. The counter is cleared on success, and the final failure is logged once at `warn` (`Giving up on metadata for album <id> after 3 attempts`) rather than at `debug` forever.

## Tests

3 new cases in `download-engine.test.ts`:

- a stream that delivers a chunk then goes silent → rejects with `stalled`
- a connection that never delivers a first byte → rejects with `stalled`
- a slow transfer with a chunk every 50s → still completes, so the timeout does not punish slow-but-alive links

The first two are genuine regression tests: on the current code they hang until vitest's 5s test timeout, which is the bug.

`npm test` 232 passed (31 files), `tsc --noEmit` clean, `npm run lint` 0 errors.
