### PR TITLE
feat: docker image and environment-variable configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+node_modules
+client/node_modules
+dist
+release
+bin
+data
+downloads
+coverage
+*.log
+.DS_Store
+.env
+.env.*
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1
+
+# ---------- build ----------
+# better-sqlite3 is a native module, so the build stage needs a toolchain that
+# the runtime image does not have to carry.
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 make g++ ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# better-sqlite3 ships prebuilt binaries linked against a newer glibc than this
+# base provides, and `npm rebuild` fetches those prebuilds rather than compiling.
+# Build it from source so it matches the runtime image, and drop the prebuilds so
+# there is nothing else for node-gyp-build to pick up.
+ENV npm_config_build_from_source=true
+
+COPY package*.json ./
+COPY client/package*.json ./client/
+RUN npm ci --ignore-scripts \
+    && npm rebuild better-sqlite3 --build-from-source \
+    && rm -rf node_modules/better-sqlite3/prebuilds \
+    && npm ci --prefix client --ignore-scripts
+
+COPY . .
+
+# Builds the dashboard bundle into src/services/dashboard/public, then compiles
+# the server to dist/. sync-version is skipped: it rewrites tracked files.
+RUN npm run build --prefix client && npm run build
+
+RUN npm prune --omit=dev \
+    && npm rebuild better-sqlite3 --build-from-source \
+    && rm -rf node_modules/better-sqlite3/prebuilds
+
+# ---------- runtime ----------
+FROM node:22-bookworm-slim AS runtime
+
+# ffmpeg does the tagging and format conversion; fpcalc (libchromaprint-tools)
+# does the audio fingerprinting used by the duplicate scanner. resolveBinaryPath
+# falls back to PATH, so installing them here is all that is needed.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg libchromaprint-tools ca-certificates tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+
+# The database and the encryption key live in ./data relative to the working
+# directory, and downloads default to /music. Mount both.
+ENV DASHBOARD_HOST=0.0.0.0 \
+    DASHBOARD_PORT=3000 \
+    DOWNLOADS_PATH=/music
+
+RUN mkdir -p /app/data /music
+VOLUME ["/app/data", "/music"]
+EXPOSE 3000
+
+# tini reaps the ffmpeg/fpcalc children this app spawns per track.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  qbz-downloader:
+    build: .
+    # image: ghcr.io/ifauzeee/qbz-downloader:latest
+    container_name: qbz-downloader
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      # Required. The dashboard refuses to serve a non-loopback address without
+      # a password, so without this the container starts but nothing is
+      # reachable on the published port.
+      DASHBOARD_PASSWORD: "change-me"
+
+      DASHBOARD_HOST: "0.0.0.0"
+      DASHBOARD_PORT: "3000"
+      DOWNLOADS_PATH: "/music"
+
+      # Any setting key works here; it applies when nothing is stored yet, and
+      # anything changed in the dashboard afterwards takes precedence.
+      # MAX_CONCURRENCY: "2"
+      # EMBED_LYRICS: "true"
+      # FOLDER_STRUCTURE: "{albumArtist}/{album}/{disc_folder}"
+    volumes:
+      # Database, settings and the encryption key.
+      - ./data:/app/data
+      # Music library.
+      - /path/to/music:/music

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -66,3 +66,45 @@ describe('CONFIG dashboard runtime overrides', () => {
         expect(settingsGet).toHaveBeenCalledTimes(14);
     });
 });
+
+describe('CONFIG environment fallback (server / container installs)', () => {
+    afterEach(() => {
+        process.env = { ...originalEnv };
+        vi.resetModules();
+        vi.doUnmock('./services/settings.js');
+    });
+
+    it('reads a setting from the environment when nothing is stored', async () => {
+        process.env.DASHBOARD_HOST = '0.0.0.0';
+        process.env.DOWNLOADS_PATH = '/music';
+
+        const { CONFIG } = await loadConfigWithSettings({});
+
+        expect(CONFIG.dashboard.host).toBe('0.0.0.0');
+        expect(CONFIG.download.outputDir).toBe('/music');
+    });
+
+    it('lets a stored setting win over the environment', async () => {
+        process.env.DASHBOARD_HOST = '0.0.0.0';
+
+        const { CONFIG } = await loadConfigWithSettings({ DASHBOARD_HOST: '10.0.0.5' });
+
+        expect(CONFIG.dashboard.host).toBe('10.0.0.5');
+    });
+
+    it('coerces numeric environment values', async () => {
+        process.env.DASHBOARD_PORT = '8080';
+
+        const { CONFIG } = await loadConfigWithSettings({});
+
+        expect(CONFIG.dashboard.port).toBe(8080);
+    });
+
+    it('ignores an empty environment value and uses the default', async () => {
+        process.env.DASHBOARD_HOST = '';
+
+        const { CONFIG } = await loadConfigWithSettings({});
+
+        expect(CONFIG.dashboard.host).toBe('127.0.0.1');
+    });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,14 @@ eventBus.on(EVENTS.SETTINGS.UPDATED, () => {
 
 const getSetting = <T>(key: string, def: T): T => {
     const fromDb = settingsService.get(key);
-    const raw = fromDb;
+
+    // Environment variables supply the value when nothing is stored, so a server
+    // or container install can be configured declaratively (DASHBOARD_HOST,
+    // DOWNLOADS_PATH, ...) instead of only through the dashboard. A stored
+    // setting still wins, so changing something in the UI keeps working and
+    // existing installs are unaffected.
+    const fromEnv = process.env[key];
+    const raw = fromDb !== undefined ? fromDb : fromEnv === '' ? undefined : fromEnv;
 
     if (raw === undefined) return def;
     if (raw === 'true') return true as T;


### PR DESCRIPTION
Adds a Dockerfile, compose file and `.dockerignore` so the app can run headless on a NAS or home server, plus the one change it needs to be configurable there.

Built and run end to end before opening this — see Verification below.

## Environment variables did not reach the config in server mode

`getSetting()` reads only `settingsService.get()`, which is backed solely by the `app_settings` table. The env-var path (`getDesktopStr`/`getDesktopInt`) is gated behind `QBZ_DESKTOP=1`, and that flag also short-circuits the auth middleware (`dashboard/index.ts:125`), so a container cannot borrow it to get env support.

That leaves no way to configure a container: `DASHBOARD_HOST`, `DOWNLOADS_PATH` and the rest are ignored, and every Docker/Unraid template configures through env.

`getSetting()` now falls back to `process.env[key]` when nothing is stored. A stored value still wins, so anything changed in the dashboard keeps working and existing installs behave exactly as before; an empty env value is treated as unset.

**Worth your call:** I chose *stored wins over env* to avoid changing behaviour for current users. Some container images do the reverse so the template stays authoritative. Happy to flip it if you'd prefer that.

## Docker

- Multi-stage: the toolchain (`python3 make g++`) stays in the build stage; the runtime carries only the app.
- `ffmpeg` and `libchromaprint-tools` (fpcalc) come from apt. `resolveBinaryPath()` already falls back to `PATH`, so `scripts/bundle-binaries.cjs` is not needed in the image.
- `tini` as entrypoint to reap the ffmpeg/fpcalc children spawned per track.
- Volumes: `/app/data` (the DB and `.secret.key` both resolve from `process.cwd()`) and `/music`.
- `npm prune --omit=dev` before the runtime copy.

**better-sqlite3 needs building from source here.** Its published prebuilds link against a newer glibc than bookworm provides, and `npm rebuild` fetches those prebuilds rather than compiling. The first image I built started cleanly and then failed on every database call with:

```
Database init failed: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found
  (required by /app/node_modules/better-sqlite3/prebuilds/linux-arm64.node)
```

So both `npm rebuild` calls use `--build-from-source`, and the `prebuilds/` directory is removed so `node-gyp-build` cannot prefer it.

## Note on the dashboard password

`docker-compose.yml` marks `DASHBOARD_PASSWORD` as required. It is only advisory today, but if #77 lands the dashboard will refuse a non-loopback bind without one and fall back to `127.0.0.1` — which in a container means nothing reaches the published port. Flagging so the two stay consistent.

## Verification

Built with Docker 29.5.2 (colima, linux/arm64) and run:

| Check | Result |
|---|---|
| `docker build` | succeeds, 1.05 GB |
| Container starts | `Database initialized: /app/data/qbz.db`, 0 errors |
| DB persists to the host bind mount | `qbz.db` present on the host |
| `GET /api/queue` without password | `401` |
| `GET /api/queue` with `x-password` | `200` |
| Dashboard UI | `200` |
| `ffmpeg -version` in image | 5.1.9 |
| `fpcalc -version` in image | 1.5.1 |

Env fallback also confirmed outside Docker by running `dist/index.js` with `DASHBOARD_HOST=0.0.0.0 DASHBOARD_PORT=3999 DASHBOARD_PASSWORD=...`: it bound `*:3999` and logged "Password protection enabled", neither of which happened before this change.

4 new cases in `config.test.ts`: env used when nothing is stored, stored value winning over env, numeric coercion, and an empty env value falling through to the default.

`npm test` 228 passed, `tsc --noEmit` clean, `npm run lint` 0 errors.

Not included: a published image or CI to build one, and no Unraid template — happy to follow up with either.
