### PR TITLE
fix: UNSYNCEDLYRICS line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [5.3.4] - 2026-07-26
+## [5.4.0] - 2026-07-26
 
 ### Fixed
 - **FLAC tagging always fails on non-Windows platforms** — `writeFlacTags()` writes the tagged output to a temporary file with a `.tmp` extension. Since ffmpeg selects the output muxer based on the file extension and `.tmp` does not match any known format, every tag write fails with `Unable to find a suitable output format`. The downloader then treats the track as failed and removes the file, resulting in complete batch downloads with nothing on disk. The output muxer is now forced with `-f flac` before the output path — the output is always FLAC here (`-c copy` from a FLAC input). Reported and fixed by @ICHlMOKU (see issue #58).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # 🎵 QBZ-Downloader
 ### *The Ultimate High-Resolution Audio Downloader & Library Manager*
 
-[![Version](https://img.shields.io/badge/version-5.3.4-6366f1?style=for-the-badge&logo=github)](https://github.com/ifauzeee/QBZ-Downloader/releases)
+[![Version](https://img.shields.io/badge/version-5.4.0-6366f1?style=for-the-badge&logo=github)](https://github.com/ifauzeee/QBZ-Downloader/releases)
 [![Windows](https://img.shields.io/badge/Windows-EXE-0078d4?style=flat-square&logo=windows)](https://github.com/ifauzeee/QBZ-Downloader/releases/latest)
 [![macOS](https://img.shields.io/badge/macOS-DMG-000000?style=flat-square&logo=apple)](https://github.com/ifauzeee/QBZ-Downloader/releases/latest)
 [![Linux](https://img.shields.io/badge/Linux-AppImage-fcc624?style=flat-square&logo=linux)](https://github.com/ifauzeee/QBZ-Downloader/releases/latest)

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qbz-downloader-client",
   "private": true,
-  "version": "5.3.4",
+  "version": "5.4.0",
   "type": "module",
   "overrides": {
     "brace-expansion": "5.0.8",

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "QBZ Downloader",
     "short_name": "QBZ-DL",
-    "version": "5.3.4",
+    "version": "5.4.0",
     "start_url": "/",
     "display": "standalone",
     "theme_color": "#0070f3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbz-downloader",
-  "version": "5.3.4",
+  "version": "5.4.0",
   "description": "Desktop-first Qobuz downloader EXE with Hi-Res audio, metadata automation, and lyrics support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -608,10 +608,25 @@ export class MetadataService {
         if (lyrics) {
             const synced = lyrics.syncedLyrics;
             const plain = lyrics.plainLyrics || lyrics.syncedLyrics;
-            
+
+            // Derive proper plain text with line breaks from synced lyrics
+            // when the API only returns plain text as a single continuous string.
+            const safePlain = (() => {
+                const raw = typeof plain === 'string' ? plain : '';
+                if (raw && raw.includes('\n')) return raw;
+                // Strip LRC timestamps to get proper line-separated plain text
+                if (synced) {
+                    const stripped = (typeof synced === 'string' ? synced : '')
+                        .replace(/^\[\d{2}:\d{2}\.\d{2,3}\]\s*/gm, '')
+                        .trim();
+                    if (stripped) return stripped;
+                }
+                return raw;
+            })();
+
             // Priority for unsynchronisedLyrics: synced (LRC format) then plain
             // Many modern players (BlackPlayer, Musicolet, etc.) look for LRC in USLT
-            const mainLyrics = synced || plain;
+            const mainLyrics = synced || safePlain;
 
             if (mainLyrics) {
                 tags.unsynchronisedLyrics = {
@@ -682,7 +697,6 @@ export class MetadataService {
 
         if (lyrics) {
             const synced = lyrics.syncedLyrics;
-            const plain = lyrics.plainLyrics || lyrics.syncedLyrics;
 
             if (synced) {
                 const syncedStr = typeof synced === 'string' ? synced : '';
@@ -691,13 +705,21 @@ export class MetadataService {
                 comments.push(['LYRICS', syncedStr]);
             }
 
+            // LRCLIB returns plainLyrics as a single continuous string without \n.
+            // When available, strip timestamps from synced lyrics to get proper line breaks.
+            const rawPlain = typeof lyrics.plainLyrics === 'string' ? lyrics.plainLyrics : '';
+            const plain = rawPlain && rawPlain.includes('\n')
+                ? rawPlain
+                : synced
+                    ? (typeof synced === 'string' ? synced : '').replace(/^\[\d{2}:\d{2}\.\d{2,3}\]\s*/gm, '').trim()
+                    : rawPlain;
+
             if (plain) {
-                const plainStr = typeof plain === 'string' ? plain : '';
-                comments.push(['UNSYNCEDLYRICS', plainStr]);
-                comments.push(['UNSYNCED LYRICS', plainStr]);
+                comments.push(['UNSYNCEDLYRICS', plain]);
+                comments.push(['UNSYNCED LYRICS', plain]);
                 // If no synced lyrics, use plain for the main tag
                 if (!synced) {
-                    comments.push(['LYRICS', plainStr]);
+                    comments.push(['LYRICS', plain]);
                 }
             }
 


### PR DESCRIPTION
LRCLIB returns plainLyrics as one continuous string without newlines. Now when writing FLAC Vorbis comments and MP3 ID3 tags, the plain text is derived from the synced lyrics (timestamps stripped) to ensure proper line breaks. Fixes UNSYNCEDLYRICS and UNSYNCED LYRICS tags showing all lyrics as a single paragraph.