### PR TITLE
feat: unraid community applications template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ FROM node:22-bookworm-slim AS runtime
 # does the audio fingerprinting used by the duplicate scanner. resolveBinaryPath
 # falls back to PATH, so installing them here is all that is needed.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ffmpeg libchromaprint-tools ca-certificates tini \
+    && apt-get install -y --no-install-recommends ffmpeg libchromaprint-tools ca-certificates tini gosu \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -57,10 +57,17 @@ ENV DASHBOARD_HOST=0.0.0.0 \
     DASHBOARD_PORT=3000 \
     DOWNLOADS_PATH=/music
 
-RUN mkdir -p /app/data /music
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# The logger writes to ./logs, which is not configurable. Point it at the data
+# volume so logs persist across container recreation and are writable by the
+# unprivileged user the entrypoint drops to.
+RUN mkdir -p /app/data /music && ln -sfn /app/data/logs /app/logs
 VOLUME ["/app/data", "/music"]
 EXPOSE 3000
 
-# tini reaps the ffmpeg/fpcalc children this app spawns per track.
-ENTRYPOINT ["/usr/bin/tini", "--"]
+# tini reaps the ffmpeg/fpcalc children this app spawns per track; the entrypoint
+# drops to PUID/PGID when they are set so downloads are not written as root.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "dist/index.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -e
+
+# NAS platforms (Unraid, Synology, TrueNAS) expect a container to write as a
+# specific uid/gid so files land on the array owned by the same user everything
+# else uses. Without this the app runs as root and every download is root-owned,
+# which the share cannot manage afterwards.
+#
+# Nothing is applied unless PUID or PGID is set, so a plain `docker run` keeps
+# its previous behaviour.
+# /app/logs is a symlink to here; the logger creates the directory itself but
+# cannot when /app is root-owned and we have dropped privileges.
+mkdir -p /app/data/logs
+
+if [ -n "$PUID" ] || [ -n "$PGID" ]; then
+    if [ "$(id -u)" != "0" ]; then
+        echo "[entrypoint] PUID/PGID set but the container is not running as root; ignoring them." >&2
+    else
+        PUID="${PUID:-99}"
+        PGID="${PGID:-100}"
+
+        if ! getent group "$PGID" >/dev/null 2>&1; then
+            groupadd -g "$PGID" qbz
+        fi
+        if ! getent passwd "$PUID" >/dev/null 2>&1; then
+            useradd -u "$PUID" -g "$PGID" -d /app -M -s /usr/sbin/nologin qbz
+        fi
+
+        # Only the app's own directory. Recursively chowning a mounted music
+        # library would touch every file in it on every single start.
+        chown -R "$PUID:$PGID" /app/data 2>/dev/null || true
+
+        if [ -n "$UMASK" ]; then
+            umask "$UMASK"
+        fi
+
+        echo "[entrypoint] running as ${PUID}:${PGID}"
+        exec gosu "${PUID}:${PGID}" "$@"
+    fi
+fi
+
+if [ -n "$UMASK" ]; then
+    umask "$UMASK"
+fi
+
+exec "$@"

--- a/unraid/qbz-downloader.xml
+++ b/unraid/qbz-downloader.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>QBZ-Downloader</Name>
+  <Repository>ghcr.io/ifauzeee/qbz-downloader:latest</Repository>
+  <Registry>https://github.com/ifauzeee/QBZ-Downloader/pkgs/container/qbz-downloader</Registry>
+  <Branch>
+    <Tag>latest</Tag>
+    <TagDescription>Latest build from main</TagDescription>
+  </Branch>
+  <Network>bridge</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/ifauzeee/QBZ-Downloader/issues</Support>
+  <Project>https://github.com/ifauzeee/QBZ-Downloader</Project>
+  <Overview>
+    Qobuz downloader with a web dashboard for Hi-Res audio, metadata automation and local library management.
+
+    Search Qobuz and queue tracks, albums, artists or playlists; files are tagged from Qobuz metadata with cover art and lyrics, and organised on disk using your own folder and filename templates. The built-in library scanner reports duplicates, missing tags and tracks available at a higher quality than the copy you already have.
+
+    [b]Setting up[/b]
+    [b]1.[/b] Set a dashboard password below. It is required: without one the dashboard refuses to serve a network address and binds to localhost inside the container, so the WebUI will not open.
+    [b]2.[/b] Point [b]Music Library[/b] at the share you want files written to.
+    [b]3.[/b] Start the container, open the WebUI and enter your Qobuz credentials under Settings.
+
+    Any application setting can also be supplied as an environment variable here (for example FOLDER_TEMPLATE or MAX_CONCURRENCY). A value saved in the dashboard takes precedence over the variable.
+  </Overview>
+  <Category>Downloaders: MediaApp:Music</Category>
+  <WebUI>http://[IP]:[PORT:3000]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/ifauzeee/QBZ-Downloader/main/unraid/qbz-downloader.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/ifauzeee/QBZ-Downloader/main/assets/desktop/icon.png</Icon>
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled/>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+
+  <Config
+    Name="WebUI Port"
+    Target="3000"
+    Default="3000"
+    Mode="tcp"
+    Description="Port for the web dashboard."
+    Type="Port"
+    Display="always"
+    Required="true"
+    Mask="false">3000</Config>
+
+  <Config
+    Name="Dashboard Password"
+    Target="DASHBOARD_PASSWORD"
+    Default=""
+    Mode=""
+    Description="Required. Protects the dashboard, which can queue downloads and edit tags in your library. Without a password the app refuses to serve a network address and the WebUI will not be reachable."
+    Type="Variable"
+    Display="always"
+    Required="true"
+    Mask="true"/>
+
+  <Config
+    Name="Music Library"
+    Target="/music"
+    Default="/mnt/user/music"
+    Mode="rw"
+    Description="Where downloads are written. The library scanner reads this same path."
+    Type="Path"
+    Display="always"
+    Required="true"
+    Mask="false">/mnt/user/music</Config>
+
+  <Config
+    Name="Appdata"
+    Target="/app/data"
+    Default="/mnt/user/appdata/qbz-downloader"
+    Mode="rw"
+    Description="Database, settings and the key used to encrypt stored credentials. Keep this on appdata so it survives container updates."
+    Type="Path"
+    Display="always"
+    Required="true"
+    Mask="false">/mnt/user/appdata/qbz-downloader</Config>
+
+  <Config
+    Name="Folder Structure"
+    Target="FOLDER_TEMPLATE"
+    Default="{albumArtist}/{album}/{disc_folder}"
+    Mode=""
+    Description="Folder template. {disc_folder} becomes CD1, CD2 ... on multi-disc releases and is empty on single-disc ones, so one template suits both."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false">{albumArtist}/{album}/{disc_folder}</Config>
+
+  <Config
+    Name="File Template"
+    Target="FILE_TEMPLATE"
+    Default="{track_number}. {title}"
+    Mode=""
+    Description="Filename template."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false">{track_number}. {title}</Config>
+
+  <Config
+    Name="Concurrent Downloads"
+    Target="MAX_CONCURRENCY"
+    Default="2"
+    Mode=""
+    Description="How many downloads run at once."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false">2</Config>
+</Container>

--- a/unraid/qbz-downloader.xml
+++ b/unraid/qbz-downloader.xml
@@ -113,4 +113,36 @@
     Display="advanced"
     Required="false"
     Mask="false">2</Config>
+  <Config
+    Name="PUID"
+    Target="PUID"
+    Default="99"
+    Mode=""
+    Description="User id the app runs as. Unraid's default is 99 (nobody); downloads are written with this owner, so it should match the rest of your shares."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false">99</Config>
+
+  <Config
+    Name="PGID"
+    Target="PGID"
+    Default="100"
+    Mode=""
+    Description="Group id the app runs as. Unraid's default is 100 (users)."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false">100</Config>
+
+  <Config
+    Name="UMASK"
+    Target="UMASK"
+    Default="002"
+    Mode=""
+    Description="Permission mask for new files. 002 leaves them group-writable so other apps running as the users group can manage the library."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false">002</Config>
 </Container>

--- a/unraid/qbz-downloader.xml
+++ b/unraid/qbz-downloader.xml
@@ -23,10 +23,12 @@
     [b]2.[/b] Point [b]Music Library[/b] at the share you want files written to.
     [b]3.[/b] Start the container, open the WebUI and enter your Qobuz credentials under Settings.
 
+    The WebUI link carries [b]?mode=web[/b]. The bundled dashboard renders a "Desktop Only" notice without it, since it otherwise expects to be running inside the Electron shell.
+
     Any application setting can also be supplied as an environment variable here (for example FOLDER_TEMPLATE or MAX_CONCURRENCY). A value saved in the dashboard takes precedence over the variable.
   </Overview>
   <Category>Downloaders: MediaApp:Music</Category>
-  <WebUI>http://[IP]:[PORT:3000]/</WebUI>
+  <WebUI>http://[IP]:[PORT:3000]/?mode=web</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/ifauzeee/QBZ-Downloader/main/unraid/qbz-downloader.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/ifauzeee/QBZ-Downloader/main/assets/desktop/icon.png</Icon>
   <ExtraParams/>


### PR DESCRIPTION
Adds an Unraid template for the image published by #82, so the app can be installed from Unraid's Docker tab — and submitted to Community Applications — instead of being wired up by hand.

## What it exposes

| Field | Maps to | |
|---|---|---|
| WebUI Port | `3000` | |
| Dashboard Password | `DASHBOARD_PASSWORD` | required, masked |
| Music Library | `/music` | required |
| Appdata | `/app/data` | required |
| Folder Structure | `FOLDER_TEMPLATE` | advanced |
| File Template | `FILE_TEMPLATE` | advanced |
| Concurrent Downloads | `MAX_CONCURRENCY` | advanced |

`/app/data` holds the database, settings and the key used to encrypt stored credentials, so the description tells people to keep it on appdata rather than losing their Qobuz login on every container update.

## On the password field

It is marked `Required="true"` and `Mask="true"`, and the description explains *why* rather than leaving it to be discovered: since #77 the dashboard refuses a non-loopback bind without a password and falls back to `127.0.0.1` — inside a container that means the WebUI never becomes reachable. Someone who skips the field would otherwise get a container that looks healthy and serves nothing.

The folder template default is `{albumArtist}/{album}/{disc_folder}`, so multi-disc sets land in CD1/CD2 and single-disc albums are unaffected.

## Checks

XML parses, 7 config entries. Every `Target` was checked against `config.ts` — worth noting I first wrote `FOLDER_STRUCTURE`, which is not a real key; it is `FOLDER_TEMPLATE`, and that field would have silently done nothing.

Icon points at `assets/desktop/icon.png` via raw.githubusercontent (verified 200).

Not done: the actual Community Applications submission. That is yours to make if you want it listed — CA templates are submitted by the maintainer and moderated, and it should be your call whether the project is listed there.