### PR TITLE
fix: login is impossible over http because Web Crypto is unavailable

### DIFF
--- a/client/src/components/Modals.tsx
+++ b/client/src/components/Modals.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { smartFetch } from '../utils/api';
 import { useToast } from '../contexts/ToastContext';
-import { sha256 } from '../utils/crypto';
+import { normalizePasswordForAuth } from '../utils/crypto';
 import { useSettings } from '../contexts/SettingsContext';
 
 interface AddUrlModalProps {
@@ -156,14 +156,22 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onSuccess }) => {
             });
 
             if (res.ok) {
-                const hash = await sha256(password);
-                sessionStorage.setItem('dashboard_password', hash);
+                // normalizePasswordForAuth falls back to the plaintext when Web
+                // Crypto is unavailable. Calling sha256 directly threw on any
+                // plain-http origin, leaving the user locked out *after* the
+                // server had already accepted the password.
+                const token = await normalizePasswordForAuth(password);
+                sessionStorage.setItem('dashboard_password', token);
                 onSuccess();
             } else {
-                setError('Invalid password');
+                setError(
+                    res.status === 429
+                        ? 'Too many attempts. Wait a moment and try again.'
+                        : 'Invalid password'
+                );
             }
         } catch (err) {
-            setError('Connection failed');
+            setError(`Could not sign in: ${err instanceof Error ? err.message : String(err)}`);
         } finally {
             setLoading(false);
         }
@@ -209,7 +217,7 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onSuccess }) => {
                                 onChange={(e) => setPassword(e.target.value)}
                                 className={error ? 'input-error' : ''}
                             />
-                            {error && <span className="error-text">Invalid password</span>}
+                            {error && <span className="error-text">{error}</span>}
                         </div>
 
                         <button

--- a/client/src/utils/crypto.ts
+++ b/client/src/utils/crypto.ts
@@ -1,3 +1,11 @@
+/**
+ * Web Crypto is only exposed in secure contexts: https:// or localhost. The
+ * dashboard is normally reached at http://<lan-ip>:<port> once it runs in a
+ * container, and there `crypto.subtle` is undefined - so hashing throws.
+ */
+const hasSubtleCrypto = (): boolean =>
+    typeof globalThis.crypto !== 'undefined' && typeof globalThis.crypto.subtle !== 'undefined';
+
 export async function sha256(message: string): Promise<string> {
     const msgBuffer = new TextEncoder().encode(message);
     const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
@@ -10,5 +18,12 @@ export async function normalizePasswordForAuth(password: string | null): Promise
     const value = password || '';
     if (!value) return '';
     if (/^[a-f0-9]{64}$/i.test(value)) return value;
+
+    // Fall back to the plaintext the server also accepts. It is no weaker here:
+    // an origin without Web Crypto is plain http, so the password is already
+    // travelling in the clear either way. Throwing instead would break login
+    // entirely on exactly the deployment the container is built for.
+    if (!hasSubtleCrypto()) return value;
+
     return sha256(value);
 }


### PR DESCRIPTION
The dashboard cannot be logged into over `http://<lan-ip>:<port>` — the way it is reached once it runs in a container. The password is accepted by the server and the user is still locked out.

## Cause

`handleLogin` awaits `sha256(password)` *after* a successful verify:

```js
if (res.ok) {
    const hash = await sha256(password);   // crypto.subtle.digest(...)
    sessionStorage.setItem('dashboard_password', hash);
    onSuccess();
}
```

Web Crypto is only exposed in secure contexts (https or localhost). On a plain-http LAN origin `crypto.subtle` is `undefined`, so this throws. The server has already returned 200 — the throw simply skips `sessionStorage` and `onSuccess`, and the lock screen stays up.

Measured in the browser at such an origin:

```
isSecureContext: false
crypto.subtle:   undefined
digest:          TypeError: Cannot read properties of undefined (reading 'digest')
```

And the request itself, captured from the page:

```
/api/auth/verify  x-password: <correct>   ->  status 200, ok true
```

200, and still locked out.

## Why it was undiagnosable

The error label was hardcoded:

```jsx
{error && <span className="error-text">Invalid password</span>}
```

It renders that string whenever the error state is set, so the thrown `TypeError` — which had called `setError('Connection failed')` — displayed as **"Invalid password"**. Every failure mode reports as a wrong password: a crash, a rate limit, a network fault. I lost a long debugging session to this before checking the response status directly, and I doubt I'm the first.

## Changes

- `normalizePasswordForAuth` falls back to the plaintext when Web Crypto is missing. The server accepts plaintext on the same endpoint, and an origin without Web Crypto is plain http — the password is already in the clear, so hashing there protected nothing.
- `handleLogin` uses that helper instead of calling `sha256` directly, so it cannot throw on the success path.
- The label renders the actual error, and a 429 is reported as rate limiting rather than a bad password.

## Verification

Against a container on a LAN origin (`isSecureContext=false`, `crypto.subtle` undefined), driving the real form:

| | before | after |
|---|---|---|
| lock screen after submit | still shown | gone |
| error text | "Invalid password" | none |
| session token | never stored | stored |

Client `tsc -b` clean, client build clean, backend suite unaffected.

Worth noting this makes the container genuinely usable — before it, the published image could only be logged into via localhost or an SSH tunnel.