### PR TITLE
fix(settings): let environment variables win on every start, not just the first

### DIFF
--- a/src/services/settings.test.ts
+++ b/src/services/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SettingsService } from './settings.js';
 import { databaseService } from './database/index.js';
 
@@ -90,7 +90,42 @@ describe('SettingsService', () => {
         vi.mocked(databaseService.getDb().prepare('').all).mockReturnValueOnce([
             { key: 'LOADED', value: 'yes' }
         ]);
-        
+
         expect(settings.get('LOADED')).toBe('yes');
+    });
+
+    describe('environment overrides', () => {
+        afterEach(() => {
+            delete process.env.DASHBOARD_PASSWORD;
+        });
+
+        it('should let an env var override a value already stored in the database', () => {
+            process.env.DASHBOARD_PASSWORD = 'from-env';
+            vi.mocked(databaseService.getDb().prepare('').all).mockReturnValueOnce([
+                { key: 'DASHBOARD_PASSWORD', value: 'enc_from-database' }
+            ]);
+
+            expect(settings.get('DASHBOARD_PASSWORD')).toBe('from-env');
+            expect(encryptionService.encryptSync).toHaveBeenCalledWith('from-env');
+        });
+
+        it('should keep the stored value when the env var is not set', () => {
+            vi.mocked(databaseService.getDb().prepare('').all).mockReturnValueOnce([
+                { key: 'DASHBOARD_PASSWORD', value: 'enc_from-database' }
+            ]);
+
+            expect(settings.get('DASHBOARD_PASSWORD')).toBe('from-database');
+            expect(encryptionService.encryptSync).not.toHaveBeenCalledWith('from-database');
+        });
+
+        it('should not rewrite the database when env matches the stored value', () => {
+            process.env.DASHBOARD_PASSWORD = 'same-value';
+            vi.mocked(databaseService.getDb().prepare('').all).mockReturnValueOnce([
+                { key: 'DASHBOARD_PASSWORD', value: 'enc_same-value' }
+            ]);
+
+            expect(settings.get('DASHBOARD_PASSWORD')).toBe('same-value');
+            expect(encryptionService.encryptSync).not.toHaveBeenCalledWith('same-value');
+        });
     });
 });

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -102,28 +102,38 @@ export class SettingsService {
                 logger.success(`Loaded ${this.cache.size} setting(s) from database`, 'SETTINGS');
             }
 
-            if (this.cache.size === 0) {
-                let seeded = 0;
-                const upsert = db.prepare(
-                    `INSERT INTO app_settings (key, value, updated_at)
-                     VALUES (?, ?, CURRENT_TIMESTAMP)
-                     ON CONFLICT(key) DO UPDATE SET
-                        value = excluded.value,
-                        updated_at = CURRENT_TIMESTAMP`
+            // An explicitly set environment variable is authoritative on every start, not just
+            // the first one. Container users configure the app through their compose file or
+            // Unraid template and expect an edit there to take effect; before this, the stored
+            // value silently won and the template field looked broken. Keys left unset in the
+            // environment are untouched, so the UI stays in charge of everything else.
+            const upsert = db.prepare(
+                `INSERT INTO app_settings (key, value, updated_at)
+                 VALUES (?, ?, CURRENT_TIMESTAMP)
+                 ON CONFLICT(key) DO UPDATE SET
+                    value = excluded.value,
+                    updated_at = CURRENT_TIMESTAMP`
+            );
+
+            const appliedKeys: string[] = [];
+            for (const key of KNOWN_SETTING_KEYS) {
+                const value = process.env[key];
+                if (value === undefined || value === '') continue;
+                if (this.cache.get(key)?.value === value) continue;
+
+                const valueToStore = SENSITIVE_KEYS.includes(key)
+                    ? encryptionService.encryptSync(value)
+                    : value;
+                upsert.run(key, valueToStore);
+                this.cache.set(key, { value, timestamp: Date.now() });
+                appliedKeys.push(key);
+            }
+
+            if (appliedKeys.length > 0) {
+                logger.info(
+                    `Applied ${appliedKeys.length} setting(s) from environment: ${appliedKeys.join(', ')}`,
+                    'SETTINGS'
                 );
-
-                for (const key of KNOWN_SETTING_KEYS) {
-                    const value = process.env[key];
-                    if (value !== undefined && value !== '') {
-                        upsert.run(key, value);
-                        this.cache.set(key, { value, timestamp: Date.now() });
-                        seeded++;
-                    }
-                }
-
-                if (seeded > 0) {
-                    logger.info(`Migrated ${seeded} setting(s) from environment to local database`, 'SETTINGS');
-                }
             }
 
             this.initialized = true;


### PR DESCRIPTION
Settings supplied through the environment are only written to the database when that database is completely empty. From the second start onward the stored value silently takes precedence, so editing a variable in a `docker-compose.yml` or an Unraid template has no effect — and nothing tells the user why.

This is most visible with `DASHBOARD_PASSWORD`. A container user changes the password in their template, restarts, and is still rejected with "Invalid password", because the value the app actually checks is the one that was seeded into the database on day one. I hit this myself running the container, and it is not obvious even when you know the codebase.

### The change

An explicitly set environment variable now wins on every start.

- Keys left unset in the environment are untouched, so the dashboard UI stays in charge of everything else.
- A value that already matches what is stored is skipped rather than rewritten, so this does not touch the database on a normal restart.
- Sensitive values arriving from the environment were being written to the database in plaintext (the old seed path called `upsert.run(key, value)` directly). They now go through `encryptSync` like every other write path. Existing plaintext rows keep working, since `decryptSync` passes through values that are not encrypted.

### Why this direction

Env-wins is the behaviour people expect from a containerised app: the compose file or template is the configuration, and a change there takes effect on restart. The alternative — keeping stored-wins and documenting it — leaves a template field that appears editable but is inert after first run, which is the confusing part.

### Tests

Three cases added to `src/services/settings.test.ts`:

- env var overrides a value already stored in the database
- stored value is kept when the env var is not set
- database is not rewritten when env matches what is stored

`npm test` → 239 passed (31 files). `npx tsc --noEmit` clean. `npm run lint` → 0 errors (the 14 warnings are pre-existing, in other files).

### Note for #83

This makes the `DASHBOARD_PASSWORD` field in the Unraid template actually work. Happy to update the template description in that PR to match once you have had a look at this one.