### PR TITLE
fix(dashboard): require the dashboard password for media routes too

### DIFF
--- a/src/services/dashboard/index.ts
+++ b/src/services/dashboard/index.ts
@@ -23,6 +23,56 @@ export interface DashboardConfig {
     enabled: boolean;
 }
 
+// Set when a password is accepted, so that plain browser requests carry proof of
+// login on their own. An <audio> or <img> element cannot attach an x-password
+// header, which is why /api/stream and /api/preview used to skip authentication
+// altogether; a cookie closes that gap without changing how the player works.
+const SESSION_COOKIE = 'qbz_session';
+
+function readSessionCookie(req: Request): string | undefined {
+    const header = req.headers.cookie;
+    if (!header) return undefined;
+
+    for (const part of header.split(';')) {
+        const separator = part.indexOf('=');
+        if (separator === -1) continue;
+        if (part.slice(0, separator).trim() !== SESSION_COOKIE) continue;
+
+        try {
+            return decodeURIComponent(part.slice(separator + 1).trim());
+        } catch {
+            return undefined;
+        }
+    }
+
+    return undefined;
+}
+
+function sha256Hex(value: string): string {
+    return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+// Accepts either the password itself or its SHA-256 hex digest, which is what the
+// browser keeps after logging in so the plaintext never has to be stored.
+function matchesDashboardPassword(provided: string, password: string): boolean {
+    try {
+        const candidate = Buffer.from(provided);
+        const plain = Buffer.from(password);
+        if (candidate.length === plain.length && crypto.timingSafeEqual(candidate, plain)) {
+            return true;
+        }
+
+        if (provided.length === 64) {
+            const expected = Buffer.from(sha256Hex(password));
+            return candidate.length === expected.length && crypto.timingSafeEqual(candidate, expected);
+        }
+    } catch (err) {
+        logger.error(`Auth comparison error: ${err}`, 'AUTH');
+    }
+
+    return false;
+}
+
 export class DashboardService {
     private app: Express;
     private httpServer: HttpServer;
@@ -83,35 +133,21 @@ export class DashboardService {
             }
 
             const providedPassword = req.headers['x-password'] || req.query.pw;
-            if (providedPassword && typeof providedPassword === 'string') {
-                try {
-                    const provided = Buffer.from(providedPassword);
-                    const plain = Buffer.from(password);
-                    if (
-                        provided.length === plain.length &&
-                        crypto.timingSafeEqual(provided, plain)
-                    ) {
-                        res.json({ success: true });
-                        return;
-                    }
-
-                    if (providedPassword.length === 64) {
-                        const expectedHash = crypto
-                            .createHash('sha256')
-                            .update(password)
-                            .digest('hex');
-                        const expected = Buffer.from(expectedHash);
-                        if (
-                            provided.length === expected.length &&
-                            crypto.timingSafeEqual(provided, expected)
-                        ) {
-                            res.json({ success: true });
-                            return;
-                        }
-                    }
-                } catch (err) {
-                    logger.error(`Auth verify error: ${err}`, 'AUTH');
-                }
+            if (
+                providedPassword &&
+                typeof providedPassword === 'string' &&
+                matchesDashboardPassword(providedPassword, password)
+            ) {
+                // A session cookie, so it is discarded when the browser closes and
+                // matches how the client already scopes the password to the tab.
+                res.cookie(SESSION_COOKIE, sha256Hex(password), {
+                    httpOnly: true,
+                    sameSite: 'strict',
+                    secure: req.secure,
+                    path: '/'
+                });
+                res.json({ success: true });
+                return;
             }
 
             res.status(401).json({ error: 'Invalid password' });
@@ -124,12 +160,15 @@ export class DashboardService {
             // Bypass password protection entirely in Desktop mode
             if (!password || isDesktop) return next();
 
+            // Only what the lock screen itself needs before anyone has logged in.
+            // Media routes are deliberately absent: they serve the library, so
+            // exempting them left every track readable to anyone who could reach
+            // the port, which matters the moment the dashboard is put behind a
+            // domain rather than kept on a LAN.
             const excludedRoutes = [
                 '/api/status',
                 '/api/themes',
-                '/api/onboarding',
-                '/api/stream/',
-                '/api/preview/'
+                '/api/onboarding'
             ];
 
             const isExcluded = excludedRoutes.some((route) => req.path.startsWith(route));
@@ -138,26 +177,15 @@ export class DashboardService {
             const isProtected = req.path.startsWith('/api') || req.path.startsWith('/downloads');
             if (!isProtected) return next();
 
-            const providedPassword = req.headers['x-password'] || req.query.pw;
+            const providedPassword =
+                req.headers['x-password'] || req.query.pw || readSessionCookie(req);
 
-            if (providedPassword && typeof providedPassword === 'string' && password) {
-                try {
-                    // Check plaintext
-                    const isPlainMatch = providedPassword.length === password.length && 
-                                       crypto.timingSafeEqual(Buffer.from(providedPassword), Buffer.from(password));
-                    
-                    if (isPlainMatch) return next();
-
-                    // Check SHA-256 hash (64 chars)
-                    if (providedPassword.length === 64) {
-                        const expectedHash = crypto.createHash('sha256').update(password).digest('hex');
-                        if (crypto.timingSafeEqual(Buffer.from(providedPassword), Buffer.from(expectedHash))) {
-                            return next();
-                        }
-                    }
-                } catch (err) {
-                    logger.error(`Auth check error: ${err}`, 'AUTH');
-                }
+            if (
+                providedPassword &&
+                typeof providedPassword === 'string' &&
+                matchesDashboardPassword(providedPassword, password)
+            ) {
+                return next();
             }
 
             res.status(401).json({ error: 'Unauthorized: Dashboard password required' });


### PR DESCRIPTION
`/api/stream` and `/api/preview` are in the `excludedRoutes` list in `src/services/dashboard/index.ts`, so they serve the library with no password at all, even when `DASHBOARD_PASSWORD` is set. The lock screen appears, but the audio is reachable straight past it:

```
curl http://host:3000/api/stream/<id>     # 200, no password
```

On a LAN this is easy to miss. It matters as soon as the dashboard goes behind a reverse proxy and a domain — the library is then readable by anyone who finds the host, while the UI still says "Access Restricted". I hit this putting the container behind Nginx Proxy Manager and ended up stacking basic auth in front just to cover these two routes.

### Why they were excluded

This looks deliberate, not careless. `client/src/components/Player.tsx:218` does:

```ts
audioRef.current.src = `/api/stream/${track.id}`;
```

An `<audio>` element cannot attach an `x-password` header, so exempting the route was the only thing that made preview work. Removing the exclusion on its own would break the player.

### The change

A session cookie, which the browser attaches to media requests by itself. Set when a password is accepted, so the two routes come off the exclusion list and `Player.tsx` is untouched.

- `httpOnly` — page scripts cannot read it
- `sameSite=strict` — another site cannot pull audio from the dashboard
- `secure` when the request arrived over TLS, so it still works on a plain-http LAN
- session-scoped, matching the `sessionStorage` the client already uses
- stores the SHA-256 digest, not the password

Desktop mode still bypasses auth entirely (`QBZ_DESKTOP=1`), and the `x-password` header and `?pw=` query paths are unchanged, so any existing client keeps working.

Also folds the duplicated comparison into `matchesDashboardPassword` — it was written out twice, with slightly different length handling in each copy.

### Verified in a container

Built the image, ran it with `DASHBOARD_PASSWORD=secret123`:

| check | result |
|---|---|
| `/api/stream/1` not logged in | **401** |
| wrong password | 401 |
| correct password | 200, `qbz_session` issued |
| `/api/stream/1` with cookie | 404 — auth passed, empty library |
| `/api/status` (lock screen) | 200 |

`npm test` → 236 passed (31 files). `npx tsc --noEmit` clean. `npm run lint` → 0 errors.