### PR TITLE
fix(client): keep web mode across navigation and refresh

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,9 +2,10 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { resolveWebMode } from './utils/webMode.js'
 
 const isDesktop = typeof window !== 'undefined' && Boolean(window.qbzDesktop?.isDesktop);
-const isWebMode = typeof window !== 'undefined' && window.location.search.includes('mode=web');
+const isWebMode = resolveWebMode();
 const root = document.getElementById('root');
 
 if (!root) {

--- a/client/src/utils/webMode.test.ts
+++ b/client/src/utils/webMode.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveWebMode, WEB_MODE_KEY } from './webMode.js';
+
+// resolveWebMode only reads window.location.search and window.localStorage, so a
+// small stub covers it without pulling in a DOM implementation.
+function stubWindow(search: string, store: Record<string, string> = {}, throwOnAccess = false) {
+    (globalThis as { window?: unknown }).window = {
+        location: { search },
+        localStorage: {
+            getItem: (key: string) => {
+                if (throwOnAccess) throw new Error('storage disabled');
+                return key in store ? store[key] : null;
+            },
+            setItem: (key: string, value: string) => {
+                if (throwOnAccess) throw new Error('storage disabled');
+                store[key] = value;
+            },
+            removeItem: (key: string) => {
+                if (throwOnAccess) throw new Error('storage disabled');
+                delete store[key];
+            }
+        }
+    };
+    return store;
+}
+
+describe('resolveWebMode', () => {
+    beforeEach(() => {
+        delete (globalThis as { window?: unknown }).window;
+    });
+
+    afterEach(() => {
+        delete (globalThis as { window?: unknown }).window;
+    });
+
+    it('enables web mode when the query string asks for it', () => {
+        stubWindow('?mode=web');
+        expect(resolveWebMode()).toBe(true);
+    });
+
+    it('remembers the choice so a later page without the query still works', () => {
+        const store = stubWindow('?mode=web');
+        resolveWebMode();
+
+        // What a refresh on /search looks like: same origin, no query string.
+        stubWindow('', store);
+        expect(resolveWebMode()).toBe(true);
+    });
+
+    it('stays disabled when nothing has ever asked for web mode', () => {
+        stubWindow('');
+        expect(resolveWebMode()).toBe(false);
+    });
+
+    it('lets ?mode=desktop turn it back off', () => {
+        const store = stubWindow('?mode=web');
+        resolveWebMode();
+
+        stubWindow('?mode=desktop', store);
+        expect(resolveWebMode()).toBe(false);
+        expect(store[WEB_MODE_KEY]).toBeUndefined();
+
+        stubWindow('', store);
+        expect(resolveWebMode()).toBe(false);
+    });
+
+    it('falls back to the query string when storage is unavailable', () => {
+        stubWindow('?mode=web', {}, true);
+        expect(resolveWebMode()).toBe(true);
+
+        stubWindow('', {}, true);
+        expect(resolveWebMode()).toBe(false);
+    });
+
+    it('ignores a mode value that merely contains the word', () => {
+        stubWindow('?notmode=website');
+        expect(resolveWebMode()).toBe(false);
+    });
+});

--- a/client/src/utils/webMode.ts
+++ b/client/src/utils/webMode.ts
@@ -1,0 +1,29 @@
+export const WEB_MODE_KEY = 'qbz_web_mode';
+
+// ?mode=web only ever appears on the first URL someone opens. Routing to /search
+// or reloading drops the query string, so reading it alone turns every refresh
+// and every bookmarked deep link into the desktop-only notice. Remember the
+// choice instead, and let ?mode=desktop undo it.
+export function resolveWebMode(): boolean {
+    if (typeof window === 'undefined') return false;
+
+    const requested = new URLSearchParams(window.location.search).get('mode');
+
+    try {
+        if (requested === 'web') {
+            window.localStorage.setItem(WEB_MODE_KEY, '1');
+            return true;
+        }
+
+        if (requested === 'desktop') {
+            window.localStorage.removeItem(WEB_MODE_KEY);
+            return false;
+        }
+
+        return window.localStorage.getItem(WEB_MODE_KEY) === '1';
+    } catch {
+        // Storage access throws when cookies are blocked. A fresh ?mode=web link
+        // still works; it just will not be remembered.
+        return requested === 'web';
+    }
+}


### PR DESCRIPTION
The desktop-only notice is skipped when the URL carries `?mode=web`, but `client/src/main.tsx` reads that straight off `window.location.search` on every load:

```ts
const isWebMode = typeof window !== "undefined" && window.location.search.includes("mode=web");
```

The flag only exists on the first URL that gets opened. Navigating to `/search`, hitting reload, or opening a bookmarked deep link all arrive with no query string, so the app decides it is the desktop build and shows "QBZ Downloader Desktop Only".

Reproduced on a Docker deployment: open `/?mode=web`, click Search, refresh — the app is replaced by the desktop-only notice.

### The change

Remember the choice in `localStorage` instead of re-reading the URL each time, and let `?mode=desktop` clear it so the opt-in stays reversible.

The gate itself is unchanged — nobody reaches the web UI without asking for it once. This only stops the answer being forgotten on the next page.

Also switches from a substring test to `URLSearchParams`, so `?notmode=website` no longer counts as opting in.

### Tests

`resolveWebMode` is extracted to `client/src/utils/webMode.ts` so it can be covered directly. Six cases, including the exact failure above: opt in once, then load a page with no query string and expect web mode to survive.

The test lives in the client suite, which the Tests workflow already runs after installing client dependencies.

- client: `npm test` → 82 passed (16 files)
- server: `npm test` → 239 passed (31 files)
- `npm run lint` → 0 errors

### Verified on a live deployment

Built the image from this branch and ran it on an Unraid server:

1. `/?mode=web` → app loads
2. Click Search, then refresh → app stays (previously the desktop-only notice)
3. `/search` with no query string at all → still works
4. `/?mode=desktop` → notice returns, opt-out works