### PR TITLE
fix(metadata): improve ffmpeg tagging error for non-ASCII paths on Windows

### DIFF
--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -861,8 +861,24 @@ export class MetadataService {
             await new Promise<void>((resolve, reject) => {
                 execFile(ffmpeg, args, { timeout: 60000 }, (error, _stdout, stderr) => {
                     if (error) {
-                        const detail = (stderr || error.message || '').trim().split('\n').slice(-3).join('\n');
-                        reject(new Error(`ffmpeg tagging failed: ${detail || error.message}`));
+                        const fullDetail = (stderr || error.message || '').trim();
+                        const detail = fullDetail.split('\n').slice(-10).join('\n');
+                        let msg = `ffmpeg tagging failed: ${detail || error.message}`;
+
+                        // On Windows, bundled ffmpeg may use ANSI file APIs that
+                        // cannot handle non-ASCII paths (Issue #50, dogiale70 report
+                        // with Japanese characters).  Detect this and give the user
+                        // an actionable hint rather than a cryptic "Invalid argument".
+                        if (process.platform === 'win32') {
+                            const hasNonAscii = [...filePath].some((c) => c.charCodeAt(0) > 127);
+                            if (hasNonAscii && (fullDetail.includes('Invalid argument') || fullDetail.includes('muxer'))) {
+                                msg += ' — The output path contains non-ASCII characters that the bundled ' +
+                                    'ffmpeg build may not support on this Windows version. Try a shorter ' +
+                                    'ALL-ASCII download path in Settings.';
+                            }
+                        }
+
+                        reject(new Error(msg));
                     } else {
                         resolve();
                     }


### PR DESCRIPTION
## What

Improves the error message when ffmpeg tagging fails on Windows with non-ASCII paths (Japanese, Cyrillic, etc.)

## Changes

1. **More stderr context**: capture 10 lines instead of 3 for actionable error output
2. **Unicode path hint**: detect Windows + non-ASCII path + ffmpeg \Invalid argument\/muxer error and append a user-facing hint suggesting an ASCII-only download path

## References

- Issue #50 (dogiale70 report with Japanese path characters)
- Comment: https://github.com/ifauzeee/QBZ-Downloader/issues/50#issuecomment-5132987709