### PR TITLE
fix(test): raise timeout for slow database migration test

### DIFF
--- a/src/services/database/database.test.ts
+++ b/src/services/database/database.test.ts
@@ -103,7 +103,7 @@ describe('DatabaseService', () => {
             expect(backupColumns.some((column) => column.name === 'file_mtime_ms')).toBe(false);
 
             fs.rmSync(tempDir, { recursive: true, force: true });
-        });
+        }, 30000);
 
         it('should migrate tracks quality scan cache columns with a v12 backup', () => {
             dbService.close();


### PR DESCRIPTION
## What

The \should create a same-directory backup before migrating a file database\ test in \src/services/database/database.test.ts\ legitimately exceeds vitest's default 5000ms timeout on slow CI runners (9s observed on windows-latest), causing flaky failures unrelated to the change under test.

Raises the per-test timeout to 30000ms.

## Verification

- 239/239 backend tests pass locally
- Windows CI was flaky on this test (timed out at 5000ms, passed on rerun)