### PR TITLE
fix(build): use packager.projectDir in ad-hoc signing hook

### DIFF
--- a/scripts/adhoc-sign-mac.cjs
+++ b/scripts/adhoc-sign-mac.cjs
@@ -95,7 +95,7 @@ module.exports = async function afterPack(context) {
     const targets = [...bundles, ...binaries].sort(byDepthDesc);
     console.info(`[adhoc-sign-mac] Ad-hoc signing ${targets.length} targets (${binaries.length} binaries, ${bundles.length} bundles)...`);
 
-    const entitlements = path.join(context.projectDir, 'assets', 'desktop', 'entitlements.mac.plist');
+    const entitlements = path.join(context.packager.projectDir, 'assets', 'desktop', 'entitlements.mac.plist');
     const entitlementsFlag = fs.existsSync(entitlements) ? ['--entitlements', entitlements] : [];
     const signArgs = ['--force', '--sign', '-', '--timestamp=none', '--options=runtime', ...entitlementsFlag];
 


### PR DESCRIPTION
## Problem

The macOS release job for v5.5.1 failed during packaging:

```
[adhoc-sign-mac] Ad-hoc signing 8 targets (0 binaries, 8 bundles)...
⨯ The "path" argument must be of type string. Received undefined
    at Object.join (node:path:1354:7)
    at afterPack (scripts/adhoc-sign-mac.cjs:98:31)
```

The `afterPack` context (`PackContext`) has **no top-level `projectDir` field** — it exposes only `appOutDir`, `outDir`, `arch`, `targets`, `packager`, `electronPlatformName`. `path.join(undefined, ...)` threw, failing the whole mac build. The hook had never run in CI before (macOS release job is the first execution of this code path).

## Fix

Access the project root via `context.packager.projectDir` (verified in app-builder-lib types: `Packager.projectDir: string`).

## Verification

- `node --check` passes, full test suite 239/239 passes locally
- Next release run will exercise the hook for real