### PR TITLE
fix(build): only export signing env vars when secrets exist

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -192,26 +192,51 @@ jobs:
 
       - name: Publish to GitHub Releases (tag only)
         if: startsWith(github.ref, 'refs/tags/v')
-        run: npx electron-builder --mac dmg zip --publish always
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
-          CSC_IDENTITY_AUTO_DISCOVERY: false
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          MAC_APPLE_ID: ${{ secrets.APPLE_ID }}
+          MAC_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          MAC_APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          # Only export signing/notarization env vars when the secrets exist.
+          # An empty CSC_LINK makes electron-builder try to read a cert from an
+          # empty path and crash with "<projectDir> not a file".
+          if [ -n "$MAC_CSC_LINK" ]; then
+            export CSC_LINK="$MAC_CSC_LINK"
+            export CSC_KEY_PASSWORD="$MAC_CSC_KEY_PASSWORD"
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
+          fi
+          if [ -n "$MAC_APPLE_ID" ]; then
+            export APPLE_ID="$MAC_APPLE_ID"
+            export APPLE_APP_SPECIFIC_PASSWORD="$MAC_APPLE_APP_SPECIFIC_PASSWORD"
+            export APPLE_TEAM_ID="$MAC_APPLE_TEAM_ID"
+          fi
+          npx electron-builder --mac dmg zip --publish always
 
       - name: Build artifacts only (manual dispatch)
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        run: npx electron-builder --mac dmg zip --publish never
+        shell: bash
         env:
-          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
-          CSC_IDENTITY_AUTO_DISCOVERY: false
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          MAC_APPLE_ID: ${{ secrets.APPLE_ID }}
+          MAC_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          MAC_APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [ -n "$MAC_CSC_LINK" ]; then
+            export CSC_LINK="$MAC_CSC_LINK"
+            export CSC_KEY_PASSWORD="$MAC_CSC_KEY_PASSWORD"
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
+          fi
+          if [ -n "$MAC_APPLE_ID" ]; then
+            export APPLE_ID="$MAC_APPLE_ID"
+            export APPLE_APP_SPECIFIC_PASSWORD="$MAC_APPLE_APP_SPECIFIC_PASSWORD"
+            export APPLE_TEAM_ID="$MAC_APPLE_TEAM_ID"
+          fi
+          npx electron-builder --mac dmg zip --publish never
 
       - name: Upload macOS artifacts
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Problem

The macOS job of desktop-release fails right after the ad-hoc signing hook runs:

```
• empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
⨯ /Users/runner/work/QBZ-Downloader/QBZ-Downloader not a file
```

## Root cause

The workflow sets `CSC_LINK: ${{ secrets.MAC_CSC_LINK }}`. When the repo has no signing secrets, GitHub substitutes an **empty string** — not `undefined`. electron-builder sees `CSC_LINK` defined (even though empty), tries to read a certificate from that path, resolves the empty path to the project dir, and crashes with `not a file`.

## Fix

Export `CSC_LINK`, `CSC_KEY_PASSWORD`, `CSC_IDENTITY_AUTO_DISCOVERY`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` **only when the corresponding secret is non-empty** (checked in the step script). Unsigned builds keep working through the ad-hoc signing hook, and nothing changes when real signing secrets are configured later.

## Verification

`npm test`: 239 passed. Release v5.5.1 macOS job will be re-run after merge.
