### PR TITLE
fix(build): sign the macOS bundle so the v5.5.1 arm64 release stops reporting "damaged"

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build full project
-        run: npm run build:full
-
       - name: Verify version consistency
         run: |
           node -e "
@@ -70,6 +67,9 @@ jobs:
             if(r!==c||r!==m){console.error('Version mismatch!');process.exit(1);}
             console.log('All versions consistent: '+r);
           "
+
+      - name: Build full project
+        run: npm run build:full
 
       - name: Run backend tests
         run: npm test
@@ -156,9 +156,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build full project
-        run: npm run build:full
-
       - name: Verify version consistency
         run: |
           node -e "
@@ -169,6 +166,9 @@ jobs:
             if(r!==c||r!==m){console.error('Version mismatch!');process.exit(1);}
             console.log('All versions consistent: '+r);
           "
+
+      - name: Build full project
+        run: npm run build:full
 
       - name: Run backend tests
         run: npm test
@@ -239,7 +239,7 @@ jobs:
           npx electron-builder --mac dmg zip --publish never
 
       - name: Upload macOS artifacts
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: macos-build
@@ -300,9 +300,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build full project
-        run: npm run build:full
-
       - name: Verify version consistency
         run: |
           node -e "
@@ -313,6 +310,9 @@ jobs:
             if(r!==c||r!==m){console.error('Version mismatch!');process.exit(1);}
             console.log('All versions consistent: '+r);
           "
+
+      - name: Build full project
+        run: npm run build:full
 
       - name: Run backend tests
         run: npm test
@@ -345,7 +345,7 @@ jobs:
         run: npx electron-builder --linux AppImage deb tar.gz --publish never
 
       - name: Upload Linux artifacts
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: linux-build

--- a/README.md
+++ b/README.md
@@ -115,15 +115,25 @@ QBZ-Downloader ships as a native desktop application for all three major platfor
 - **macOS:** `.dmg` disk image for Apple Silicon (arm64); Intel support is planned for a future release
 - **Linux:** `.AppImage` (portable), `.deb` (Debian / Ubuntu), or `.tar.gz` archive
 
-> **macOS Gatekeeper note:** builds made without notarization credentials are
-> ad-hoc signed and may still be flagged by macOS with *"…is damaged and can't
-> be opened"* or *"Apple cannot check it for malicious software"* because the
-> app is not notarized by Apple.
-> To run an unsigned build, right-click the app and select **Open**, or remove
-> the quarantine attribute once:
+> **macOS Gatekeeper note:** builds made without Apple Developer credentials
+> are ad-hoc signed but **not notarized**, so the first launch of a downloaded
+> copy is blocked with *"Apple could not verify … is free of malicious
+> software."* This is expected. Either open it once via **System Settings →
+> Privacy & Security → Open Anyway**, or clear the quarantine attribute after
+> dragging the app to `/Applications`:
 >
 > ```bash
-> xattr -cr "/Applications/QBZ Downloader.app"
+> xattr -dr com.apple.quarantine "/Applications/QBZ Downloader.app"
+> ```
+>
+> If macOS instead reports *"…is damaged and can't be opened"*, the bundle's
+> code signature is invalid rather than merely unnotarized — that is a build
+> bug, not a Gatekeeper policy, and no workaround should be needed. Please
+> [open an issue](https://github.com/ifauzeee/QBZ-Downloader/issues). You can
+> confirm a good build yourself with:
+>
+> ```bash
+> codesign --verify --deep --strict --verbose=2 "/Applications/QBZ Downloader.app"
 > ```
 >
 > Releases built with Apple Developer ID credentials configured in CI (secrets
@@ -151,17 +161,17 @@ Build artifacts are written to the `release/` directory:
 - **Linux:** `QBZ-Downloader-<version>-x86_64.AppImage`, `.deb`, and `.tar.gz`
 
 ### Pre-Release Builds (CI Artifacts)
-When a fix has been merged to `main` but a formal release has not yet been cut, you can download the latest CI build directly from GitHub Actions:
+When a fix has been merged to `main` but a formal release has not yet been cut, you can build the current `main` from CI:
 
 1. Navigate to the [Actions tab](https://github.com/ifauzeee/QBZ-Downloader/actions) and select the **Desktop Release** workflow.
-2. Open the latest green-checkmarked run.
-3. Scroll down to the **Artifacts** section and download your platform's bundle:
-   - `Windows-Installer` — the `.exe` installer
-   - `macOS-DMG` — the `.dmg` disk image
-   - `Linux-AppImage` — the portable `.AppImage`
+2. Trigger it with **Run workflow** (the workflow only runs automatically for `v*` tags).
+3. Open the run and, once it is green, download your platform's bundle from the **Artifacts** section:
+   - `qbz-desktop-release` — the Windows `.exe` installer and portable build
+   - `macos-build` — the `.dmg` and `.zip`
+   - `linux-build` — the `.AppImage`, `.deb` and `.tar.gz`
 4. Extract the archive and run the installer. No build tools are required.
 
-> These builds are compiled from the latest `main` branch using the same CI pipeline that produces official releases. They are functionally identical to a tagged release — the only difference is the absence of a version tag.
+> These builds are compiled from the selected branch using the same CI pipeline that produces official releases. They are functionally identical to a tagged release — the only difference is the absence of a version tag.
 
 ### Docker (for NAS / Headless Servers)
 A pre-built multi-architecture Docker image is available for server and NAS deployments. It bundles ffmpeg, fpcalc, and the full dashboard behind a password-protected web interface.

--- a/assets/desktop/entitlements.mac.plist
+++ b/assets/desktop/entitlements.mac.plist
@@ -6,8 +6,6 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
 </dict>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "desktop:dist": "npm run desktop:dist:win",
     "desktop:dist:win": "npm run build:full && npm run desktop:rebuild && electron-builder --win nsis",
     "desktop:dist:portable": "npm run build:full && npm run desktop:rebuild && electron-builder --win portable",
-    "desktop:dist:mac": "npm run build:full && npm run desktop:rebuild && electron-builder --mac dmg zip",
+    "desktop:dist:mac": "npm run build:full && node scripts/rebuild-electron-native.cjs arm64 && electron-builder --mac dmg zip",
     "desktop:dist:linux": "npm run build:full && npm run desktop:rebuild && electron-builder --linux AppImage deb tar.gz",
     "desktop:dist:all": "npm run build:full && npm run desktop:rebuild && electron-builder --win nsis portable --mac dmg zip --linux AppImage deb tar.gz",
     "prepare": "husky"

--- a/scripts/adhoc-sign-mac.cjs
+++ b/scripts/adhoc-sign-mac.cjs
@@ -10,11 +10,14 @@ const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const MACHO_MAGIC = [
-    0xcf, 0xfa, 0xed, 0xfe, // MH_MAGIC_64
-    0xfe, 0xed, 0xfa, 0xcf, // MH_CIGAM_64
-    0xca, 0xfe, 0xba, 0xbe, // FAT_MAGIC
-    0xbe, 0xba, 0xfe, 0xca // FAT_CIGAM
+// Each entry is a complete 4-byte header magic. A file matches when its first
+// four bytes equal ONE of these — comparing against the concatenation of all
+// four (as a single flat list) can never match a real header.
+const MACHO_MAGICS = [
+    Buffer.from([0xcf, 0xfa, 0xed, 0xfe]), // MH_MAGIC_64
+    Buffer.from([0xfe, 0xed, 0xfa, 0xcf]), // MH_CIGAM_64
+    Buffer.from([0xca, 0xfe, 0xba, 0xbe]), // FAT_MAGIC
+    Buffer.from([0xbe, 0xba, 0xfe, 0xca]) // FAT_CIGAM
 ];
 
 function isMachO(file) {
@@ -22,8 +25,9 @@ function isMachO(file) {
     try {
         fd = fs.openSync(file, 'r');
         const buf = Buffer.alloc(4);
-        fs.readSync(fd, buf, 0, 4, 0);
-        return MACHO_MAGIC.every((byte, i) => buf[i] === byte);
+        const read = fs.readSync(fd, buf, 0, 4, 0);
+        if (read < 4) return false;
+        return MACHO_MAGICS.some((magic) => buf.equals(magic));
     } catch {
         return false;
     } finally {
@@ -87,27 +91,65 @@ module.exports = async function afterPack(context) {
     collect(appPath, files, bundles);
 
     const binaries = files.filter(isMachO);
-    if (binaries.length === 0 && bundles.length === 0) {
-        console.warn('[adhoc-sign-mac] no Mach-O binaries found to sign (unexpected)');
-        return;
+    if (binaries.length === 0) {
+        // The main executable alone guarantees at least one hit; zero means the
+        // walk or the header check is broken, and shipping now produces exactly
+        // the "damaged" bundle this hook exists to prevent.
+        throw new Error('[adhoc-sign-mac] no Mach-O binaries found to sign — refusing to ship an unsigned bundle');
     }
 
+    // The outer .app is not visited by collect() (it walks the bundle's
+    // contents), and it is the one seal Gatekeeper actually reads. Without it
+    // the bundle has no Contents/_CodeSignature and codesign reports
+    // "code has no resources but signature indicates they must be present".
     const targets = [...bundles, ...binaries].sort(byDepthDesc);
-    console.info(`[adhoc-sign-mac] Ad-hoc signing ${targets.length} targets (${binaries.length} binaries, ${bundles.length} bundles)...`);
+    targets.push(appPath);
+
+    console.info(
+        `[adhoc-sign-mac] Ad-hoc signing ${targets.length} targets (${binaries.length} binaries, ${bundles.length} nested bundles, 1 app)...`
+    );
 
     const entitlements = path.join(context.packager.projectDir, 'assets', 'desktop', 'entitlements.mac.plist');
-    const entitlementsFlag = fs.existsSync(entitlements) ? ['--entitlements', entitlements] : [];
-    const signArgs = ['--force', '--sign', '-', '--timestamp=none', '--options=runtime', ...entitlementsFlag];
+    const hasEntitlements = fs.existsSync(entitlements);
+
+    // Entitlements belong on the app and its helper apps, not on frameworks,
+    // dylibs or loose executables. --options=runtime is deliberately omitted:
+    // the hardened runtime only buys anything once the build is notarized, and
+    // on an ad-hoc signature it adds launch-time library-validation failures.
+    const signArgsFor = (target) => {
+        const args = ['--force', '--sign', '-', '--timestamp=none'];
+        if (hasEntitlements && target.endsWith('.app')) {
+            args.push('--entitlements', entitlements);
+        }
+        return args;
+    };
 
     try {
         for (const target of targets) {
-            execFileSync('codesign', [...signArgs, target], { stdio: 'inherit' });
+            execFileSync('codesign', [...signArgsFor(target), target], { stdio: 'inherit' });
         }
-        console.info('[adhoc-sign-mac] finished Ad-hoc signing of ' + appBundle);
     } catch (error) {
         // Ad-hoc signing failures leave the user with a repeat of the "damaged"
         // report, so fail the build loudly rather than shipping a broken bundle.
         console.error('[adhoc-sign-mac] Ad-hoc codesign failed:', error.message);
         throw error;
     }
+
+    // Verify rather than assume. The previous version of this hook silently
+    // signed nothing at all for months; a build that cannot verify must not
+    // reach a release.
+    try {
+        execFileSync('codesign', ['--verify', '--deep', '--strict', '--verbose=2', appPath], {
+            stdio: 'inherit'
+        });
+    } catch (error) {
+        console.error('[adhoc-sign-mac] signature verification failed:', error.message);
+        throw error;
+    }
+
+    console.info('[adhoc-sign-mac] finished Ad-hoc signing of ' + appBundle + ' (signature verified)');
 };
+
+// Exposed for scripts/adhoc-sign-mac.test.mjs. A silently-false isMachO shipped
+// an unsigned bundle for several releases, so the predicate is pinned by a test.
+module.exports.__test = { isMachO };

--- a/scripts/adhoc-sign-mac.test.mjs
+++ b/scripts/adhoc-sign-mac.test.mjs
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const require = createRequire(import.meta.url);
+const { __test } = require('./adhoc-sign-mac.cjs');
+const { isMachO } = __test;
+
+/**
+ * The predicate this covers used to compare a 4-byte file header against a flat
+ * 16-byte list of four alternative magics, so it returned false for every file
+ * on disk. The signing hook consequently signed zero binaries and shipped a
+ * macOS bundle with no valid signature, which Gatekeeper reports as "damaged".
+ */
+describe('adhoc-sign-mac isMachO', () => {
+    let dir;
+
+    const write = (name, bytes) => {
+        const file = path.join(dir, name);
+        fs.writeFileSync(file, Buffer.from(bytes));
+        return file;
+    };
+
+    beforeAll(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qbz-macho-'));
+    });
+
+    afterAll(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it.each([
+        ['MH_MAGIC_64', [0xcf, 0xfa, 0xed, 0xfe]],
+        ['MH_CIGAM_64', [0xfe, 0xed, 0xfa, 0xcf]],
+        ['FAT_MAGIC', [0xca, 0xfe, 0xba, 0xbe]],
+        ['FAT_CIGAM', [0xbe, 0xba, 0xfe, 0xca]]
+    ])('recognises %s', (_name, magic) => {
+        expect(isMachO(write(`macho-${_name}`, [...magic, 0x00, 0x01, 0x02, 0x03]))).toBe(true);
+    });
+
+    it('rejects a non-Mach-O file', () => {
+        expect(isMachO(write('text', [0x68, 0x65, 0x6c, 0x6c, 0x6f]))).toBe(false);
+    });
+
+    it('rejects a file shorter than the magic', () => {
+        expect(isMachO(write('tiny', [0xcf, 0xfa]))).toBe(false);
+    });
+
+    it('rejects a path that does not exist', () => {
+        expect(isMachO(path.join(dir, 'missing'))).toBe(false);
+    });
+
+    it('recognises the real Electron binary shipped in node_modules', () => {
+        const electronPath = path.resolve(
+            path.dirname(new URL(import.meta.url).pathname),
+            '..',
+            'node_modules',
+            'electron',
+            'dist',
+            'Electron.app',
+            'Contents',
+            'MacOS',
+            'Electron'
+        );
+
+        // Only meaningful on a macOS checkout with electron installed.
+        if (process.platform !== 'darwin' || !fs.existsSync(electronPath)) return;
+        expect(isMachO(electronPath)).toBe(true);
+    });
+});

--- a/scripts/bundle-binaries.cjs
+++ b/scripts/bundle-binaries.cjs
@@ -13,6 +13,7 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 const os = require('os');
+const crypto = require('crypto');
 const { execSync } = require('child_process');
 
 const platform = process.platform; // win32 | darwin | linux
@@ -53,6 +54,33 @@ function bundleFfmpeg() {
 const FPCALC_VERSION = '1.5.1';
 const FPCALC_BASE = `https://github.com/acoustid/chromaprint/releases/download/v${FPCALC_VERSION}`;
 
+// These archives are downloaded during the release build and their contents are
+// shipped inside every published artifact, so a compromised or swapped asset
+// would be signed and distributed as ours. Pin the exact bytes.
+const FPCALC_SHA256 = {
+  'chromaprint-fpcalc-1.5.1-macos-universal.tar.gz':
+    'd4d8faff4b5f7c558d9be053da47804f9501eaa6c2f87906a9f040f38d61c860',
+  'chromaprint-fpcalc-1.5.1-linux-x86_64.tar.gz':
+    '4d7433a7f778e5946d7225230681cbcd634e153316ecac87c538c33ac32387a5',
+  'chromaprint-fpcalc-1.5.1-windows-x86_64.zip':
+    '36b478e16aa69f757f376645db0d436073a42c0097b6bb2677109e7835b59bbc'
+};
+
+const MAX_REDIRECTS = 5;
+
+function verifyChecksum(filePath, url) {
+  const name = url.split('/').pop();
+  const expected = FPCALC_SHA256[name];
+  if (!expected) {
+    throw new Error(`no pinned checksum for ${name}`);
+  }
+
+  const actual = crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+  if (actual !== expected) {
+    throw new Error(`checksum mismatch for ${name}: expected ${expected}, got ${actual}`);
+  }
+}
+
 // Returns the list of target arch directories to copy fpcalc into.
 function fpcalcTargets() {
   if (platform === 'win32') {
@@ -72,9 +100,14 @@ function fpcalcTargets() {
   return [];
 }
 
-function download(url) {
+function download(url, depth = 0) {
   const isZip = url.endsWith('.zip');
   return new Promise((resolve, reject) => {
+    if (depth > MAX_REDIRECTS) {
+      reject(new Error(`too many redirects (${MAX_REDIRECTS}) fetching ${url}`));
+      return;
+    }
+
     const tmp = path.join(os.tmpdir(), `fpcalc-${Date.now()}.${isZip ? 'zip' : 'tar.gz'}`);
     const file = fs.createWriteStream(tmp);
     const req = https.get(
@@ -84,7 +117,7 @@ function download(url) {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           file.close();
           const next = new URL(res.headers.location, url).href;
-          download(next).then(resolve).catch(reject);
+          download(next, depth + 1).then(resolve).catch(reject);
           return;
         }
         if (res.statusCode !== 200) {
@@ -130,6 +163,14 @@ async function bundleFpcalc() {
     try {
       log(`downloading fpcalc from ${target.url}`);
       const tmp = await download(target.url);
+
+      try {
+        verifyChecksum(tmp, target.url);
+      } catch (err) {
+        fs.rmSync(tmp, { force: true });
+        throw err;
+      }
+
       const extractDir = path.join(os.tmpdir(), `fpcalc-extract-${Date.now()}`);
       fs.mkdirSync(extractDir, { recursive: true });
       if (target.url.endsWith('.zip')) {

--- a/scripts/rebuild-electron-native.cjs
+++ b/scripts/rebuild-electron-native.cjs
@@ -54,6 +54,12 @@ if (!rebuildCli) {
     process.exit(1);
 }
 
+// Defaults to the host arch. Pass a target explicitly (e.g. `arm64`) when
+// packaging for an architecture other than the machine doing the build —
+// otherwise better-sqlite3's .node is built for the wrong ABI and the packaged
+// app crashes the moment it opens the database.
+const targetArch = process.argv[2] || process.arch;
+
 const result = spawnSync(
     process.execPath,
     [
@@ -63,6 +69,8 @@ const result = spawnSync(
         'better-sqlite3',
         '--version',
         electronVersion,
+        '--arch',
+        targetArch,
         '--module-dir',
         root
     ],

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,10 @@
 export default {
     test: {
         environment: 'node',
-        include: ['src/**/*.test.ts'],
+        // scripts/ is included so the release-build helpers are covered too —
+        // a silent regression there ships a broken artifact rather than
+        // failing a test.
+        include: ['src/**/*.test.ts', 'scripts/**/*.test.mjs'],
         globals: true,
     },
 };


### PR DESCRIPTION
> ## ⚠️ Merge order: **independent, but do not release before #119**
>
> Three PRs came out of the same audit of `v5.5.1`: #119, #118 and **#117 (this one)**.
>
> This PR **shares no files** with the other two, so it can merge at any point without
> conflicting. But **do not cut a release before #119 lands** — #119 fixes live,
> attacker-reachable issues in the shipping build, and putting out a macOS build first
> would ship a release advertising fixes while those issues are still present.
>
> | Order | PR | Why |
> | :---: | --- | --- |
> | 1 | **#119 — security** | Fixes live, reachable issues in `v5.5.1` — must land before any release |
> | 2 | #118 — download/queue/UI bug fixes | Shares 3 files with #119 |
> | **3** | **#117 — this PR** | Independent; shares no files with either |
>
> **No rebase is needed in any order.** I tested all three merge orders against `main`:
> every one merges clean. Merging all three produces a tree I verified byte-for-byte
> against the full audit branch, which passes the complete gate.
>
> The order above is about **release safety**, not mechanics.

---

> **These fixes were derived from the latest release, `v5.5.1` (tag `v5.5.1`, commit `9f95524`).**
> **They are live bugs affecting the published build, not regressions in unreleased work.**

## The problem

The published macOS arm64 build does not launch. macOS reports **"QBZ Downloader is damaged and can't be opened. You should move it to the Trash."** and no Gatekeeper override helps — because the bundle's code signature is **invalid**, not merely unnotarized.

I reproduced this locally by packaging under the same conditions as CI (no signing identity on the runner):

```
[adhoc-sign-mac] Ad-hoc signing 8 targets (0 binaries, 8 bundles)

$ codesign --verify --deep --strict "QBZ Downloader.app"
QBZ Downloader.app: code has no resources but signature indicates they must be present
```

**Zero binaries signed**, and no `Contents/_CodeSignature` on the app at all.

## Root cause

Two defects in the `afterPack` hook combined:

1. **`isMachO()` could never return true.** `MACHO_MAGIC` held four alternative 4-byte header magics in one flat 16-element array, and the check required all sixteen entries to match a 4-byte buffer. `buf[4..15]` are `undefined`, so the predicate returned `false` for every file on disk.
2. **The outer `.app` was never a signing target.** `collect()` walks the bundle's *contents*, so the app itself was never added to the bundle list and its seal was never written.

electron-builder does not cover for this. With no identity on the runner, `MacTargetHelper.findSigningIdentity` returns `null` and signing is skipped entirely (`skipped macOS application code signing`), so this hook is the only signer in the pipeline.

## The fix

- Compare the file header against each magic separately.
- Sign the outer `.app` last, after the nested bundles and binaries.
- Apply entitlements only to `.app` bundles, and drop `--options=runtime` — the hardened runtime buys nothing on an unnotarized ad-hoc signature and only adds launch-time library-validation failures.
- **Fail the build** when zero binaries are found, and run `codesign --verify --deep --strict` before an artifact can ship, so this cannot silently regress again.

After the fix, the same build reports:

```
[adhoc-sign-mac] Ad-hoc signing 30 targets (21 binaries, 8 nested bundles, 1 app)
QBZ Downloader.app: valid on disk
QBZ Downloader.app: satisfies its Designated Requirement
```

I packaged and launched the result on an M-series Mac (macOS 26.5): the app boots, spawns its helper processes, and loads the dashboard.

### Still needed: notarization

The build remains **unnotarized**, which requires a paid Apple Developer account. A downloaded copy is still quarantined and needs one "Open Anyway" or `xattr -dr com.apple.quarantine`. `syspolicy_check` now grades ad-hoc signing as a *Warning* ("may run locally") with only "Notary Ticket Missing" fatal — where before the signature itself was rejected. The README now describes this accurately and distinguishes it from the "damaged" failure.

## Also in this release path

- **Supply chain:** pinned SHA-256 checksums for the fpcalc archives, which are downloaded during the release build and shipped inside every artifact, and bounded the redirect chain.
- **Cross-arch:** `rebuild-electron-native.cjs` now takes a target arch, and `desktop:dist:mac` passes `arm64`, so an Intel host cannot produce an arm64 app carrying an x64 `better-sqlite3`.
- **CI:** the "Verify version consistency" step ran *after* `build:full`, i.e. after `sync-version.js` had already rewritten the files it compares — it could never fail. Moved before the build.
- **CI:** macOS and Linux artifact uploads were gated on tag refs, so `workflow_dispatch` runs produced nothing downloadable. Corrected, along with the artifact names in the README.
- Dropped the `allow-dyld-environment-variables` entitlement.
- Extended vitest to cover `scripts/`, and added a test pinning the Mach-O predicate.

## Verification

Run on this branch:

| Check | Result |
| --- | --- |
| `npm run lint` | 0 errors |
| `npx tsc --noEmit` | clean |
| `npm test` | 247 passed (32 files) |
| `cd client && npm run lint` | 0 errors |
| `cd client && npm test` | 82 passed |
| `npm audit --audit-level=high` | 0 vulnerabilities (root + client) |
| `node tests/electron-smoke.mjs` | passed |
| Real macOS package + `codesign --verify --deep --strict` | passes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
