### PR TITLE
fix(download): repair partial-file, skipExisting, empty-zip and concurrency bugs in v5.5.1

### DIFF
--- a/client/src/components/AudioVisualizer.tsx
+++ b/client/src/components/AudioVisualizer.tsx
@@ -31,6 +31,20 @@ export const AudioVisualizer: React.FC<AudioVisualizerProps> = ({
     // Keep track of which element we're connected to
     const connectedElementRef = useRef<HTMLAudioElement | null>(null);
 
+    // Browsers cap concurrent AudioContexts (~6 in Chrome). Opening and
+    // closing the player repeatedly without releasing them left the
+    // visualizer permanently dead until a page reload.
+    useEffect(
+        () => () => {
+            const ctx = audioContextRef.current;
+            audioContextRef.current = null;
+            analyserRef.current = null;
+            connectedElementRef.current = null;
+            if (ctx && ctx.state !== 'closed') ctx.close().catch(() => undefined);
+        },
+        []
+    );
+
     useEffect(() => {
         if (!audioElement || !isPlaying) {
             if (animationFrameRef.current) {

--- a/client/src/components/Player.tsx
+++ b/client/src/components/Player.tsx
@@ -93,6 +93,10 @@ export const Player: React.FC<PlayerProps> = ({ sidebarCollapsed = false }) => {
         if (!track) return;
         setLyrics(null);
         setLyricsRaw('');
+        // The editor only renders when lyricsRaw is non-empty, so a click on a
+        // track without lyrics left showEditor stuck true and the editor sprang
+        // open unrequested on the next track that had them.
+        setShowEditor(false);
 
         smartFetch(`/api/lyrics/${track.id}`)
             .then(res => res ? res.json() : null)
@@ -457,7 +461,17 @@ export const Player: React.FC<PlayerProps> = ({ sidebarCollapsed = false }) => {
                     )}
                 </div>
                 <div className="lyrics-actions" style={{ display: 'flex', gap: '10px', justifyContent: 'flex-start', marginTop: '4px' }}>
-                    <button className="icon-btn" onClick={() => setShowEditor(true)} title="Edit Lyrics">
+                    <button
+                        className="icon-btn"
+                        onClick={() => {
+                            if (!lyricsRaw) {
+                                showToast('No lyrics available to edit', 'error');
+                                return;
+                            }
+                            setShowEditor(true);
+                        }}
+                        title="Edit Lyrics"
+                    >
                         <Icons.Edit width={20} />
                     </button>
                     <button className="icon-btn" onClick={() => setIsLyricsFullscreen(!isLyricsFullscreen)} title="Toggle Fullscreen">

--- a/client/src/components/QueueView.tsx
+++ b/client/src/components/QueueView.tsx
@@ -71,6 +71,7 @@ export const QueueView: React.FC = () => {
     const parentRef = useRef<HTMLDivElement>(null);
     const [scrollMargin, setScrollMargin] = React.useState(0);
     const listRef = useRef<HTMLDivElement>(null);
+    const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         if (listRef.current && parentRef.current) {
@@ -91,9 +92,20 @@ export const QueueView: React.FC = () => {
 
         fetchQueue();
 
+        // The server emits queue:update once per second and item:* on every
+        // state change. Refetching per event burned through the API rate limit
+        // during a large batch, after which every dashboard request 429'd.
+        const scheduleFetch = () => {
+            if (refreshTimer.current) return;
+            refreshTimer.current = setTimeout(() => {
+                refreshTimer.current = null;
+                fetchQueue();
+            }, 1000);
+        };
+
         const handleQueueUpdate = (newStats: any) => {
             setStats(newStats);
-            fetchQueue();
+            scheduleFetch();
         };
 
         const handleStats = (newStats: any) => {
@@ -105,7 +117,7 @@ export const QueueView: React.FC = () => {
         };
 
         const handleRefresh = () => {
-            fetchQueue();
+            scheduleFetch();
         };
 
         socket.on('queue:update', handleQueueUpdate);
@@ -116,6 +128,10 @@ export const QueueView: React.FC = () => {
         socket.on('item:progress', handleItemProgress);
 
         return () => {
+            if (refreshTimer.current) {
+                clearTimeout(refreshTimer.current);
+                refreshTimer.current = null;
+            }
             socket.off('queue:update', handleQueueUpdate);
             socket.off('queue:stats', handleStats);
             socket.off('item:added', handleRefresh);

--- a/client/src/components/SettingsView.tsx
+++ b/client/src/components/SettingsView.tsx
@@ -5,7 +5,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { ConfirmModal } from './Modals';
 import { Icons } from './Icons';
-import { sha256 } from '../utils/crypto';
+import { normalizePasswordForAuth } from '../utils/crypto';
 
 interface AppSettings {
     QOBUZ_APP_ID: string;
@@ -273,7 +273,12 @@ export const SettingsView: React.FC = () => {
 
             if (res && res.ok) {
                 if (settingsForm.dashboardPassword.trim()) {
-                    const hash = await sha256(settingsForm.dashboardPassword.trim());
+                    // normalizePasswordForAuth falls back to the raw value
+                    // when crypto.subtle is missing (plain-http origins), instead
+                    // of throwing and locking the user out of their own change.
+                    const hash = await normalizePasswordForAuth(
+                        settingsForm.dashboardPassword.trim()
+                    );
                     sessionStorage.setItem('dashboard_password', hash);
                 }
                 showToast('Settings saved', 'success');

--- a/client/src/components/__tests__/SettingsView.test.tsx
+++ b/client/src/components/__tests__/SettingsView.test.tsx
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
     deleteTheme: vi.fn(),
     applyTheme: vi.fn(),
     resetTheme: vi.fn(),
-    sha256: vi.fn()
+    normalizePasswordForAuth: vi.fn()
 }));
 
 vi.mock('../../utils/api', () => ({
@@ -17,7 +17,7 @@ vi.mock('../../utils/api', () => ({
 }));
 
 vi.mock('../../utils/crypto', () => ({
-    sha256: mocks.sha256
+    normalizePasswordForAuth: mocks.normalizePasswordForAuth
 }));
 
 vi.mock('../../contexts/ToastContext', () => ({
@@ -124,7 +124,7 @@ function mockSettingsApi() {
 describe('SettingsView', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.sha256.mockResolvedValue('hashed-password');
+        mocks.normalizePasswordForAuth.mockResolvedValue('hashed-password');
         sessionStorage.clear();
         mockSettingsApi();
     });
@@ -195,7 +195,7 @@ describe('SettingsView', () => {
                 '"dashboard_password":"new-pass"'
             );
         });
-        expect(mocks.sha256).toHaveBeenCalledWith('new-pass');
+        expect(mocks.normalizePasswordForAuth).toHaveBeenCalledWith('new-pass');
         expect(sessionStorage.getItem('dashboard_password')).toBe('hashed-password');
     });
 });

--- a/client/src/contexts/PlayerContext.tsx
+++ b/client/src/contexts/PlayerContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
 export interface PlaybackTrack {
     id: string;
@@ -57,22 +57,41 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     const [currentTrackIndex, setCurrentTrackIndex] = useState(-1);
     const [showQueue, setShowQueue] = useState(false);
 
-    const addToPlaybackQueue = (track: PlaybackTrack, playNow = false) => {
-        const exists = playQueue.findIndex(t => t.id === track.id);
+    // Player subscribes to the 'player:play' window event once, so it holds
+    // whichever addToPlaybackQueue it saw on first render. Reading the queue
+    // from a ref instead of the closed-over state keeps that stale callback
+    // correct — otherwise every play event rebuilt the queue from the empty
+    // array captured at mount and discarded everything already in it.
+    const playQueueRef = useRef<PlaybackTrack[]>([]);
+    const currentTrackIndexRef = useRef(-1);
+
+    useEffect(() => {
+        playQueueRef.current = playQueue;
+    }, [playQueue]);
+
+    useEffect(() => {
+        currentTrackIndexRef.current = currentTrackIndex;
+    }, [currentTrackIndex]);
+
+    const addToPlaybackQueue = useCallback((track: PlaybackTrack, playNow = false) => {
+        const current = playQueueRef.current;
+        const exists = current.findIndex(t => t.id === track.id);
         if (exists !== -1) {
             if (playNow) setCurrentTrackIndex(exists);
             return;
         }
-        
-        const newQueue = [...playQueue, track];
+
+        const newQueue = [...current, track];
+        // Updated eagerly so two events in the same tick both land.
+        playQueueRef.current = newQueue;
         setPlayQueue(newQueue);
-        
+
         if (playNow) {
             setCurrentTrackIndex(newQueue.length - 1);
-        } else if (currentTrackIndex === -1) {
+        } else if (currentTrackIndexRef.current === -1) {
             setCurrentTrackIndex(0);
         }
-    };
+    }, []);
 
 
     const removeFromQueue = (index: number) => {

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -26,8 +26,12 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({ childr
             socketInstance = io('/', {
                 auth: { password },
                 transports: ['websocket', 'polling'],
-                reconnectionAttempts: 5,
-                reconnectionDelay: 1000
+                // Giving up after 5 attempts left the dashboard permanently
+                // dead — and still showing "Reconnecting" — after any restart
+                // that took more than ~5s. Back off instead of stopping.
+                reconnectionAttempts: Infinity,
+                reconnectionDelay: 1000,
+                reconnectionDelayMax: 10000
             });
 
             socketInstance.on('connect', () => {
@@ -47,6 +51,9 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({ childr
                 console.error('Socket connection error:', err.message);
                 if (err.message === 'Authentication failed') {
                     window.dispatchEvent(new CustomEvent('auth:unauthorized'));
+                    // Unlimited retries must not hammer the server with a
+                    // password that is never going to be accepted.
+                    socketInstance?.io.reconnection(false);
                 }
             });
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -13,14 +13,21 @@ try {
 const initialCwd = process.cwd();
 const net = require('net');
 
-async function findAvailablePort(startPort) {
-  return new Promise((resolve) => {
+async function findAvailablePort(startPort, attempts = 100) {
+  return new Promise((resolve, reject) => {
+    // Without a bound, a port above 65535 (or a busy range) recursed until the
+    // stack gave out and the app came up with no window and no error.
+    if (!Number.isInteger(startPort) || startPort < 1024 || startPort > 65535 || attempts <= 0) {
+      reject(new Error(`No available port found starting from ${startPort}`));
+      return;
+    }
+
     const server = net.createServer();
     server.unref();
     server.on('error', () => {
-      resolve(findAvailablePort(startPort + 1));
+      findAvailablePort(startPort + 1, attempts - 1).then(resolve, reject);
     });
-    server.listen(startPort, () => {
+    server.listen(startPort, '127.0.0.1', () => {
       server.close(() => {
         resolve(startPort);
       });
@@ -288,6 +295,9 @@ function migrateLegacyState(targetDir) {
   if (fs.existsSync(markerPath)) return;
 
   const candidates = uniqueExisting([process.env.QBZ_MIGRATE_FROM]);
+  // Nothing to migrate from: leave the marker unwritten so a later run with
+  // QBZ_MIGRATE_FROM set still gets a chance to migrate.
+  if (candidates.length === 0) return;
 
   const migrated = [];
 
@@ -298,6 +308,12 @@ function migrateLegacyState(targetDir) {
       migrated.push(`data/qbz.db <= ${candidate}`);
       copyIfMissing(path.join(candidate, 'data', 'qbz.db-wal'), path.join(targetDir, 'data', 'qbz.db-wal'));
       copyIfMissing(path.join(candidate, 'data', 'qbz.db-shm'), path.join(targetDir, 'data', 'qbz.db-shm'));
+      // Without the key file every encrypted credential in the copied database
+      // decrypts to garbage, and the user has to re-enter all of them.
+      copyIfMissing(
+        path.join(candidate, 'data', '.secret.key'),
+        path.join(targetDir, 'data', '.secret.key')
+      );
     }
 
     if (copyIfMissing(path.join(candidate, 'history.json'), path.join(targetDir, 'history.json'))) {
@@ -703,10 +719,12 @@ function registerIpc() {
 }
 
 async function bootstrap() {
-  const startPort = Number.parseInt(
+  const parsedPort = Number.parseInt(
     process.env.DESKTOP_DASHBOARD_PORT || process.env.DASHBOARD_PORT || '3210',
     10
   );
+  const startPort =
+    Number.isInteger(parsedPort) && parsedPort >= 1024 && parsedPort <= 65535 ? parsedPort : 3210;
   DESKTOP_PORT = await findAvailablePort(startPort);
   DASHBOARD_URL = `http://127.0.0.1:${DESKTOP_PORT}`;
 
@@ -771,11 +789,18 @@ if (!gotLock) {
     mainWindow.focus();
   });
 
-  app.whenReady().then(async () => {
-    setupSecurityHeaders();
-    registerIpc();
-    await bootstrap();
-  });
+  app.whenReady()
+    .then(async () => {
+      setupSecurityHeaders();
+      registerIpc();
+      await bootstrap();
+    })
+    // Otherwise a startup failure leaves a running process holding the single
+    // instance lock, and the next launch silently does nothing.
+    .catch((error) => {
+      console.error('Failed to start QBZ Downloader:', error);
+      app.quit();
+    });
 }
 
 app.on('before-quit', () => {

--- a/src/services/AIMetadataService.ts
+++ b/src/services/AIMetadataService.ts
@@ -168,7 +168,10 @@ export class AIMetadataService {
         }, {
             headers: {
                 'x-goog-api-key': apiKey
-            }
+            },
+            // This sits on the download path; without a bound a hung provider
+            // stalls the queue indefinitely.
+            timeout: 30000
         });
 
         const parsedResponse = geminiResponseSchema.safeParse(response.data);
@@ -201,7 +204,8 @@ export class AIMetadataService {
             ],
             response_format: { type: 'json_object' }
         }, {
-            headers: { 'Authorization': `Bearer ${apiKey}` }
+            headers: { 'Authorization': `Bearer ${apiKey}` },
+            timeout: 30000
         });
 
         const parsedResponse = openAIResponseSchema.safeParse(response.data);

--- a/src/services/DownloadEngine.ts
+++ b/src/services/DownloadEngine.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import path from 'path';
 import { createWriteStream, createReadStream } from 'fs';
 import { downloadFile } from '../utils/network.js';
 import { logger } from '../utils/logger.js';
@@ -71,12 +72,24 @@ export class DownloadEngine {
         const headers: Record<string, string> = {};
         let isResuming = false;
 
-        if (resumeService.canResume(trackId)) {
+        // The recorded partial has to be the file we are about to write, not
+        // just the same track id: the byte offset and the re-hash below both
+        // apply to `filePath`, so resuming against a different recorded path
+        // would append to one file using another file's length.
+        const partial = resumeService.getPartial(trackId);
+        const partialMatchesTarget =
+            !!partial && path.resolve(partial.filePath) === path.resolve(filePath);
+
+        if (partialMatchesTarget && resumeService.canResume(trackId)) {
             downloaded = resumeService.getResumePosition(trackId);
             headers['Range'] = `bytes=${downloaded}-`;
             isResuming = true;
             logger.info(`Resuming download for ${metadata.title} from ${downloaded} bytes`, 'DOWNLOAD');
         }
+
+        // Captured once: reading it again later re-stats the file as it grows,
+        // which made every resumed download report ~0 B/s.
+        const resumeStartOffset = downloaded;
 
         const response = await downloadFile(url, { headers });
         
@@ -174,7 +187,7 @@ export class DownloadEngine {
                         const currentTime = Date.now();
                         if (currentTime - lastProgressEmit >= 100 || (effectiveTotalLength > 0 && downloaded >= effectiveTotalLength)) {
                             const elapsed = (currentTime - startTime) / 1000;
-                            const speed = elapsed > 0 ? (downloaded - (isResuming ? resumeService.getResumePosition(trackId) : 0)) / elapsed : 0;
+                            const speed = elapsed > 0 ? (downloaded - resumeStartOffset) / elapsed : 0;
 
                             onProgress({
                                 phase: 'download',

--- a/src/services/LibraryStatisticsService.ts
+++ b/src/services/LibraryStatisticsService.ts
@@ -17,7 +17,8 @@ export interface LibraryStats {
 export class LibraryStatisticsService {
     async getLibraryStats(): Promise<LibraryStats> {
         try {
-            const tracks = databaseService.getAllTracks();
+            // Default page size is 100; whole-library statistics need the whole library.
+        const tracks = databaseService.getAllTracks(1_000_000, 0);
             
             const stats: LibraryStats = {
                 totalTracks: tracks.length,

--- a/src/services/database/index.ts
+++ b/src/services/database/index.ts
@@ -402,6 +402,11 @@ export class DatabaseService {
         const row = stmt.get('db_version') as { value: string } | undefined;
         const currentVersion = row ? parseInt(row.value) : 0;
 
+        // Every migration step below swallows its own error so one failure does
+        // not abort startup. Recording DB_VERSION anyway made those failures
+        // permanent: the step never runs again and the column stays missing.
+        let migrationsOk = true;
+
         if (currentVersion < 2) {
             try {
                 const tableInfo = this.db.prepare('PRAGMA table_info(tracks)').all() as {
@@ -419,6 +424,7 @@ export class DatabaseService {
                 }
             } catch (error: unknown) {
                 logger.warn(`Migration v2 partial: ${(error as Error).message}`, 'DB');
+                    migrationsOk = false;
             }
         }
 
@@ -441,6 +447,7 @@ export class DatabaseService {
                 }
             } catch (error: unknown) {
                 logger.warn(`Migration v3 partial: ${(error as Error).message}`, 'DB');
+                    migrationsOk = false;
             }
         }
 
@@ -460,6 +467,7 @@ export class DatabaseService {
                     }
                 } catch (error: unknown) {
                     logger.warn(`Migration v7 partial: ${(error as Error).message}`, 'DB');
+                    migrationsOk = false;
                 }
             }
 
@@ -479,6 +487,7 @@ export class DatabaseService {
                     }
                 } catch (error: unknown) {
                     logger.warn(`Migration v8 partial: ${(error as Error).message}`, 'DB');
+                    migrationsOk = false;
                 }
             }
 
@@ -498,6 +507,7 @@ export class DatabaseService {
                     }
                 } catch (error: unknown) {
                     logger.warn(`Migration v9 partial: ${(error as Error).message}`, 'DB');
+                    migrationsOk = false;
                 }
             }
 
@@ -519,6 +529,7 @@ export class DatabaseService {
                     }
                 } catch (error: unknown) {
                     logger.warn(`Migration v10 partial: ${(error as Error).message}`, 'DB');
+                    migrationsOk = false;
                 }
             }
 
@@ -540,6 +551,7 @@ export class DatabaseService {
                     }
                 } catch (error: unknown) {
                     logger.warn(`Migration v11 partial: ${(error as Error).message}`, 'DB');
+                    migrationsOk = false;
                 }
             }
 
@@ -574,7 +586,16 @@ export class DatabaseService {
                     }
                 } catch (error: unknown) {
                     logger.warn(`Migration v12 partial: ${(error as Error).message}`, 'DB');
+                    migrationsOk = false;
                 }
+            }
+
+            if (!migrationsOk) {
+                logger.error(
+                    `Migration to v${DB_VERSION} incomplete; version not recorded, will retry on next start`,
+                    'DB'
+                );
+                return;
             }
 
             this.db
@@ -630,7 +651,7 @@ export class DatabaseService {
             track.quality_scanned_at || null
         );
 
-        this.updateDailyStats('tracks');
+        this.updateDailyStats('tracks', track.file_size || 0);
         if (track.genre) this.updateGenreStats(track.genre, track.file_size || 0);
         if (track.quality) this.updateQualityStats(track.quality, track.file_size || 0);
         const artistForStats = track.album_artist || track.artist;

--- a/src/services/download-engine.test.ts
+++ b/src/services/download-engine.test.ts
@@ -13,6 +13,7 @@ vi.mock('../utils/network.js', () => ({
 
 vi.mock('./batch.js', () => ({
     resumeService: {
+        getPartial: vi.fn().mockReturnValue(undefined),
         canResume: vi.fn().mockReturnValue(false),
         getResumePosition: vi.fn().mockReturnValue(0),
         startDownload: vi.fn(),
@@ -156,7 +157,52 @@ describe('DownloadEngine', () => {
         await expect(downloadPromise).rejects.toThrow('selected Hi-Res candidate is likely unavailable');
     });
 
+    it('should not resume when the recorded partial points at a different file', async () => {
+        vi.mocked(resumeService.getPartial).mockReturnValue({
+            trackId: 'id',
+            filePath: 'some/other/file.flac',
+            bytesDownloaded: 500,
+            totalBytes: 1000,
+            quality: 27,
+            startedAt: new Date().toISOString()
+        });
+        vi.mocked(resumeService.canResume).mockReturnValue(true);
+        vi.mocked(resumeService.getResumePosition).mockReturnValue(500);
+
+        const mockDataStream = new EventEmitter();
+        (mockDataStream as unknown as Record<string, unknown>).pipe = vi.fn().mockReturnThis();
+        (mockDataStream as unknown as Record<string, unknown>).destroy = vi.fn();
+
+        vi.mocked(network.downloadFile).mockResolvedValue({
+            status: 200,
+            headers: { 'content-length': '1000' },
+            data: mockDataStream
+        } as unknown as AxiosResponse);
+
+        void engine.download('url', 'path', 'id', { title: 'T' } as unknown as Metadata, 1000, 27);
+
+        await vi.waitFor(() => {
+            if (vi.mocked(network.downloadFile).mock.calls.length === 0) {
+                throw new Error('not called');
+            }
+        });
+
+        // No Range header: the recorded offset belongs to another file, and
+        // applying it here would append to the wrong place.
+        const [, requestOptions] = vi.mocked(network.downloadFile).mock.calls[0]!;
+        expect((requestOptions as { headers?: Record<string, string> })?.headers?.Range).toBeUndefined();
+        expect(vi.mocked(fs.createReadStream)).not.toHaveBeenCalled();
+    });
+
     it('should handle resume if possible', async () => {
+        vi.mocked(resumeService.getPartial).mockReturnValue({
+            trackId: 'id',
+            filePath: 'path',
+            bytesDownloaded: 500,
+            totalBytes: 1000,
+            quality: 27,
+            startedAt: new Date().toISOString()
+        });
         vi.mocked(resumeService.canResume).mockReturnValue(true);
         vi.mocked(resumeService.getResumePosition).mockReturnValue(500);
 

--- a/src/services/download.ts
+++ b/src/services/download.ts
@@ -118,6 +118,19 @@ export default class DownloadService {
         return this.normalizeComparablePath(left) === this.normalizeComparablePath(right);
     }
 
+    /**
+     * Staging path for an in-flight download. Deterministic on purpose: a
+     * timestamped name would never match the path recorded by resumeService,
+     * so an interrupted transfer could never be resumed. The extension is kept
+     * because writeMetadata and the quality scanner dispatch on it.
+     */
+    private buildPartialPath(filePath: string): string {
+        const dir = path.dirname(filePath);
+        const ext = path.extname(filePath);
+        const base = path.basename(filePath, ext);
+        return path.join(dir, `${base}.qbz-part${ext}`);
+    }
+
     private buildReplacementPath(filePath: string): string {
         const dir = path.dirname(filePath);
         const ext = path.extname(filePath);
@@ -341,7 +354,12 @@ export default class DownloadService {
         const isSamePathUpgrade =
             !!sourcePath && existsSync(sourcePath) && this.pathsEqual(sourcePath, filePath);
         const shouldReplaceExisting = existsSync(filePath) && !options.skipExisting;
-        const workingFilePath = shouldReplaceExisting ? this.buildReplacementPath(filePath) : filePath;
+        // Always stage into a sibling and promote on success. Writing straight
+        // to the final path meant a crash or a kill mid-transfer left a
+        // truncated file there, which `skipExisting` then treated as a finished
+        // download forever. The name is deterministic so resumeService can
+        // still match the partial across a restart.
+        const workingFilePath = this.buildPartialPath(filePath);
 
         if (isSamePathUpgrade) {
             logger.info(
@@ -463,8 +481,8 @@ export default class DownloadService {
                 }
             }
 
+            this.replaceExistingFile(workingFilePath, filePath);
             if (shouldReplaceExisting) {
-                this.replaceExistingFile(workingFilePath, filePath);
                 logger.info(`Replaced existing file after successful download: ${filePath}`, 'DOWNLOAD');
             }
 
@@ -492,7 +510,7 @@ export default class DownloadService {
 
             resumeService.completeDownload(trackId.toString());
 
-            this.updateDatabase(trackId, metadata, actualQuality, finalFilePath, size, md5, track, album as Album, scanResult);
+            await this.updateDatabase(trackId, metadata, actualQuality, finalFilePath, size, md5, track, album as Album, scanResult);
 
             mediaServerService.notifyNewContent({
                 title: metadata.title,
@@ -505,13 +523,14 @@ export default class DownloadService {
             return { success: true, filePath, quality: actualQuality, metadata, lyrics: lyricsResult as LyricsResult };
         } catch (error: unknown) {
             const message = error instanceof Error ? error.message : String(error);
-            const cleanupPath = shouldReplaceExisting ? workingFilePath : filePath;
-            if (existsSync(cleanupPath) && (!this.pathsEqual(cleanupPath, filePath) || !shouldReplaceExisting)) {
+            // Only ever the staging file: the previously downloaded track at
+            // filePath is left untouched by a failed re-download.
+            if (existsSync(workingFilePath)) {
                 // Log before discarding: this deletion is silent otherwise, so a
                 // late-stage failure looks to the user like the file was never
                 // downloaded at all.
-                logger.warn(`Removing incomplete download "${cleanupPath}": ${message}`, 'DOWNLOAD');
-                unlinkSync(cleanupPath);
+                logger.warn(`Removing incomplete download "${workingFilePath}": ${message}`, 'DOWNLOAD');
+                unlinkSync(workingFilePath);
             }
             resumeService.completeDownload(trackId.toString());
             return { success: false, error: message };
@@ -546,21 +565,24 @@ export default class DownloadService {
         _album: Album,
         scanResult?: QualityReport
     ) {
-        historyService.add(trackId, {
-            filename: filePath,
-            quality: quality,
-            title: metadata.title,
-            artist: metadata.artist,
-            albumArtist: metadata.albumArtist || metadata.artist,
-            album: metadata.album,
-            qualityScan: scanResult ? {
-                isTrueLossless: scanResult.isTrueLossless,
-                confidence: scanResult.confidence,
-                details: scanResult.details
-            } : undefined
-        });
-
+        // Inside the try: a SQLite failure here used to escape as an unhandled
+        // rejection (the caller did not await), and once awaited it would reach
+        // downloadTrack's catch, which deletes the finished audio file.
         try {
+            historyService.add(trackId, {
+                filename: filePath,
+                quality: quality,
+                title: metadata.title,
+                artist: metadata.artist,
+                albumArtist: metadata.albumArtist || metadata.artist,
+                album: metadata.album,
+                qualityScan: scanResult ? {
+                    isTrueLossless: scanResult.isTrueLossless,
+                    confidence: scanResult.confidence,
+                    details: scanResult.details
+                } : undefined
+            });
+
             const { databaseService } = await import('./database/index.js');
             databaseService.addTrack({
                 id: trackId.toString(),
@@ -636,6 +658,7 @@ export default class DownloadService {
  
         const promises = tracks.map((track: Track) => this.concurrencyLimit(() => this.downloadTrack(track.id, requestedQuality, {
             album,
+            skipExisting: options.skipExisting,
             isCancelled: options.isCancelled,
             onProgress: (p) => {
                 if (options.onProgress) options.onProgress(track.id.toString(), {
@@ -692,6 +715,9 @@ export default class DownloadService {
 
         return {
             success: completed > 0,
+            // The batch/zip path reads `tracks` to collect the files it just
+            // produced; leaving it unset made every album/playlist zip empty.
+            tracks: results,
             completedTracks: completed,
             totalTracks: results.length,
             failedTracks: failedItems.length
@@ -715,6 +741,7 @@ export default class DownloadService {
         const tracks = playlist.tracks.items;
  
         const promises = tracks.map((track: Track) => this.concurrencyLimit(() => this.downloadTrack(track.id, requestedQuality, {
+            skipExisting: options.skipExisting,
             isCancelled: options.isCancelled,
             onProgress: (p) => {
                 if (options.onProgress) options.onProgress(track.id.toString(), {
@@ -778,6 +805,9 @@ export default class DownloadService {
 
         return {
             success: completed > 0,
+            // The batch/zip path reads `tracks` to collect the files it just
+            // produced; leaving it unset made every album/playlist zip empty.
+            tracks: results,
             completedTracks: completed,
             totalTracks: results.length,
             failedTracks: failedItems.length

--- a/src/services/integration.test.ts
+++ b/src/services/integration.test.ts
@@ -194,6 +194,9 @@ vi.mock('fs', async (importOriginal) => {
     const mockExistsSync = vi.fn().mockReturnValue(false);
     const mockMkdirSync = vi.fn();
     const mockWriteFileSync = vi.fn();
+    // Downloads are staged to a .qbz-part sibling and promoted on success.
+    const mockRenameSync = vi.fn();
+    const mockUnlinkSync = vi.fn();
     const mockCreateWriteStream = vi.fn().mockReturnValue({
         on: vi.fn().mockImplementation(function(this: { emit: (event: string) => void }, event, cb) {
             if (event === 'finish') setTimeout(cb, 10);
@@ -215,12 +218,16 @@ vi.mock('fs', async (importOriginal) => {
         existsSync: mockExistsSync,
         mkdirSync: mockMkdirSync,
         writeFileSync: mockWriteFileSync,
+        renameSync: mockRenameSync,
+        unlinkSync: mockUnlinkSync,
         createWriteStream: mockCreateWriteStream,
         default: {
             ...actual,
             existsSync: mockExistsSync,
             mkdirSync: mockMkdirSync,
             writeFileSync: mockWriteFileSync,
+            renameSync: mockRenameSync,
+            unlinkSync: mockUnlinkSync,
             createWriteStream: mockCreateWriteStream
         }
     };

--- a/src/services/library-scanner/index.ts
+++ b/src/services/library-scanner/index.ts
@@ -524,7 +524,7 @@ export class LibraryScannerService extends EventEmitter {
 
     private async checkQobuzUpgrades(filePathsToCheck?: Set<string>): Promise<number> {
         const db = databaseService.getDb();
-        const allFiles = databaseService.getLibraryFiles(10000, 0) as unknown as {
+        const allFiles = databaseService.getLibraryFiles(1_000_000, 0) as unknown as {
             file_path: string;
             track_id?: string | null;
             available_quality?: number | null;

--- a/src/services/queue-processor.test.ts
+++ b/src/services/queue-processor.test.ts
@@ -15,7 +15,8 @@ vi.mock('./queue/queue.js', () => ({
         get: vi.fn(),
         updateProgress: vi.fn(),
         updateQuality: vi.fn(),
-        requeue: vi.fn()
+        requeue: vi.fn(),
+        setMaxConcurrent: vi.fn()
     }
 }));
 

--- a/src/services/queue-processor.ts
+++ b/src/services/queue-processor.ts
@@ -7,6 +7,8 @@ import { logger } from '../utils/logger.js';
 import { QueueItem } from './queue/types.js';
 import { CONFIG } from '../config.js';
 import { notifyDownloadComplete, notifyDownloadError } from './notifications.js';
+import { eventBus, EVENTS } from '../utils/events.js';
+import { globalApiLimit } from '../utils/limit.js';
 
 /** Hydration passes to spend on one queue item before treating it as unresolvable. */
 const MAX_HYDRATION_ATTEMPTS = 3;
@@ -116,6 +118,19 @@ export class QueueProcessor {
         }
 
         this.isStarted = true;
+
+        // MAX_CONCURRENCY is editable in the UI but the queue was constructed
+        // with a hardcoded 2 and the API limiter was frozen at import time, so
+        // the setting had no effect at all. Applied here — after settings and
+        // the database are initialised — and re-applied whenever it changes.
+        const applyConcurrency = () => {
+            const concurrent = CONFIG.download.concurrent || 2;
+            downloadQueue.setMaxConcurrent(concurrent);
+            globalApiLimit.concurrency = concurrent;
+        };
+        applyConcurrency();
+        eventBus.on(EVENTS.SETTINGS.UPDATED, applyConcurrency);
+
         this.setupEvents();
         void this.startMetadataHydration();
         void this.processNext();

--- a/src/services/queue/queue.ts
+++ b/src/services/queue/queue.ts
@@ -28,6 +28,22 @@ export class DownloadQueue {
             metadata?: QueueItemMetadata;
         } = {}
     ): QueueItem {
+        // Two live items for the same content download into the same output
+        // path concurrently and interleave their writes. Completed and failed
+        // items are deliberately still re-addable.
+        const existing = Array.from(this.items.values()).find(
+            (item) =>
+                item.type === type &&
+                item.contentId.toString() === contentId.toString() &&
+                (item.status === 'pending' ||
+                    item.status === 'downloading' ||
+                    item.status === 'processing')
+        );
+        if (existing) {
+            logger.debug(`Queue: ${type} ${contentId} already queued (${existing.id})`);
+            return existing;
+        }
+
         const id = generateQueueId();
         const normalizedQuality = normalizeDownloadQuality(quality, CONFIG.quality.default);
         const item: QueueItem = {


### PR DESCRIPTION
> ## ⚠️ Merge order: **after #119**
>
> Three PRs came out of the same audit of `v5.5.1`: #119, **#118 (this one)** and #117.
>
> **Merge #119 first.** It fixes live, attacker-reachable issues in the shipping
> build; this PR contains no security content. Landing this one first and cutting a
> release would ship a build advertising fixes while those issues are still present.
>
> | Order | PR | Why |
> | :---: | --- | --- |
> | 1 | **#119 — security** | Fixes live, reachable issues in `v5.5.1` — must land first |
> | **2** | **#118 — this PR** | Shares 3 files with #119 |
> | 3 | #117 — macOS release signing | Independent; shares no files with either |
>
> **No rebase is needed in any order.** I tested all three merge orders against `main`:
> every one merges clean. This PR touches the same three files as #119
> (`electron/main.cjs`, `src/services/database/index.ts`, `src/services/download.ts`)
> but in different regions, so git auto-merges them. Merging all three produces a tree
> I verified byte-for-byte against the full audit branch, which passes the complete gate.
>
> The order above is about **release safety**, not mechanics.

---

> **These fixes were derived from the latest release, `v5.5.1` (tag `v5.5.1`, commit `9f95524`).**
> **They are live bugs affecting the published build, not regressions in unreleased work.**

Behavioural bug fixes found while auditing `v5.5.1`. No security content in this PR.

## Download integrity

**Partial downloads were indistinguishable from finished ones.** Tracks were written straight to their final path, so a crash, a kill or a power loss mid-transfer left a truncated file exactly where a completed download belongs — and `skipExisting` then treated it as complete *forever*. The track could never be repaired without deleting it by hand.

Downloads are now staged in a deterministic `<name>.qbz-part<ext>` sibling and promoted only after the transfer, checksum, tagging and quality scan all succeed. The staging name is deterministic on purpose: a timestamped one would never match the path recorded by `resumeService`, silently killing resume.

**Resume could append to the wrong file.** `resumeService.canResume` was consulted by track id alone, but the recorded byte offset belongs to `partial.filePath` while the Range request and the re-hash are applied to the engine's `filePath`. After a `DOWNLOADS_PATH`, `FOLDER_TEMPLATE` or `FILE_TEMPLATE` change, one file's length was used to append to another. The recorded path must now match the target.

**Resumed downloads reported ~0 B/s**, because the speed formula subtracted the file's current — growing — size instead of the offset it started from.

**Two queue items for the same content wrote to the same file concurrently**, interleaving their writes. `DownloadQueue.add` now returns the existing item while one is pending/downloading/processing; completed and failed items stay re-addable.

## Silently wrong results

- **Album and playlist downloads never forwarded `skipExisting`** to the per-track call, so re-queuing an album re-downloaded and replaced every track it already had.
- **Every album/playlist zip came out empty.** Neither `downloadAlbum` nor `downloadPlaylist` populated `DownloadResult.tracks`, which is exactly what the batch/zip path reads to collect the files it just produced.
- **History was silently lost on "successful" downloads.** `updateDatabase` was called without `await` or `.catch`, and `historyService.add` sat outside its `try`, so a SQLite failure became an unhandled rejection. (Ordering matters here: awaiting without first moving the history write inside the `try` would route a DB error into `downloadTrack`'s catch, which deletes the finished audio file.)
- **A failed schema migration was permanent.** Each step swallows its own error, but `db_version` was written regardless — so the step never ran again and the missing column stayed missing. The version is now only recorded when every step succeeded.
- **`MAX_CONCURRENCY` had no effect at all.** The queue was constructed with a hardcoded `2` and the API limiter was frozen at import time. Now applied on start and re-applied on settings change.
- Library statistics were computed from the **100 most recent tracks**, and the Qobuz upgrade check from the **10,000 most recently scanned files** — both silently truncated.
- `daily_stats.total_size` was never incremented; the caller omitted the size argument.

## Frontend

- **The playback queue was destroyed on every new track.** `Player` subscribes to `player:play` once with `[]` deps, capturing the initial `addToPlaybackQueue` and therefore the empty queue it closed over, so each event rebuilt the queue from scratch. Fixed in `PlayerContext` by making the mutator closure-independent rather than re-subscribing the listener on every render.
- **The dashboard could die permanently.** The socket gave up after 5 reconnect attempts and never retried, leaving a dead dashboard still displaying "Reconnecting". Now unlimited with backoff, and it stops retrying on an auth failure so a wrong password does not hammer the server.
- **QueueView could freeze the whole dashboard.** It refetched `/api/queue` once per queue socket event, exhausting the server rate limiter during a large batch. Refetches are now coalesced.
- `AudioVisualizer` created an `AudioContext` per player open and never closed it; browsers cap concurrent contexts, so the visualizer died permanently after roughly six cycles.
- Changing the dashboard password over plain HTTP threw, because `crypto.subtle` is absent outside a secure context — reporting a false failure *after* the password had already been saved.
- "Edit Lyrics" on a track without lyrics left the editor flagged open, so it appeared unrequested on the next track that had them.

## Electron shell

- `findAvailablePort` recursed unbounded, and a non-numeric or out-of-range `DASHBOARD_PORT` rejected it — leaving the app running with **no window and no error**. The port is clamped, the recursion bounded, and a startup failure now quits so the single-instance lock is released.
- `migrateLegacyState` wrote its completion marker even when there was nothing to migrate (so a later run with `QBZ_MIGRATE_FROM` set never got a chance), and never copied `data/.secret.key` — meaning a migrated database decrypted to garbage and every credential had to be re-entered.

## Verification

Run on this branch:

| Check | Result |
| --- | --- |
| `npm run lint` | 0 errors |
| `npx tsc --noEmit` | clean |
| `npm test` | 240 passed (31 files) |
| `cd client && npm run lint` | 0 errors |
| `cd client && npm test` | 82 passed |
| `npm audit --audit-level=high` | 0 vulnerabilities (root + client) |
| `node tests/electron-smoke.mjs` | passed |

Existing test doubles were updated where they encoded the old behaviour (`renameSync` for the staging path, `getPartial` for resume, `setMaxConcurrent` for concurrency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
