### PR TITLE
security(dashboard): harden authentication, process invocation and outbound requests in v5.5.1

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -12,6 +12,14 @@ try {
 
 const initialCwd = process.cwd();
 const net = require('net');
+const crypto = require('crypto');
+
+// findAvailablePort closes the probe socket before the backend binds it, so
+// another local process can win the race and serve the window instead. The
+// backend echoes this secret back on /api/status; waitForDashboard refuses to
+// load anything that cannot produce it. No CORS headers are ever set, so the
+// header stays unreadable to a cross-origin page.
+const DESKTOP_HANDSHAKE_TOKEN = crypto.randomBytes(32).toString('hex');
 
 async function findAvailablePort(startPort) {
   return new Promise((resolve) => {
@@ -347,7 +355,7 @@ async function waitForDashboard(timeoutMs = 45000) {
   while (Date.now() - start < timeoutMs) {
     try {
       const response = await fetch(`${DASHBOARD_URL}/api/status`);
-      if (response.ok) {
+      if (response.ok && response.headers.get('x-qbz-desktop-token') === DESKTOP_HANDSHAKE_TOKEN) {
         return true;
       }
     } catch {
@@ -374,6 +382,7 @@ async function startBackend() {
     process.env.DASHBOARD_PORT = String(DESKTOP_PORT);
     process.env.DASHBOARD_HOST = '127.0.0.1';
     process.env.QBZ_DESKTOP = '1';
+    process.env.QBZ_DESKTOP_TOKEN = DESKTOP_HANDSHAKE_TOKEN;
     process.env.NODE_ENV = process.env.NODE_ENV || (app.isPackaged ? 'production' : 'development');
     process.env.DOWNLOADS_PATH = process.env.DOWNLOADS_PATH || path.join(app.getPath('downloads'), 'QBZ-Downloader');
 
@@ -436,8 +445,28 @@ function createWindow() {
   });
 
   win.webContents.setWindowOpenHandler(({ url }) => {
-    void shell.openExternal(url);
+    // Only ever hand the OS a web URL. Without the scheme check any renderer
+    // could open file://, smb:// or a registered custom protocol handler.
+    let parsed = null;
+    try {
+      parsed = new URL(url);
+    } catch {
+      parsed = null;
+    }
+
+    if (parsed && (parsed.protocol === 'https:' || parsed.protocol === 'http:')) {
+      void shell.openExternal(url);
+    }
+
     return { action: 'deny' };
+  });
+
+  // The preload bridge is attached to this window, so it would travel with it
+  // to any origin the renderer navigated to.
+  win.webContents.on('will-navigate', (event, url) => {
+    if (url !== DASHBOARD_URL && !url.startsWith(`${DASHBOARD_URL}/`) && !url.startsWith('data:')) {
+      event.preventDefault();
+    }
   });
 
   return win;
@@ -478,9 +507,16 @@ function setupAutoUpdater() {
   }
 
   const rawFeed = process.env.QBZ_UPDATE_URL;
-  if (rawFeed) {
+  if (rawFeed && rawFeed.startsWith('https://')) {
     const feed = rawFeed.endsWith('/') ? rawFeed : `${rawFeed}/`;
     autoUpdater.setFeedURL({ provider: 'generic', url: feed });
+  } else if (rawFeed) {
+    // autoDownload and autoInstallOnAppQuit are both on, so a plaintext feed
+    // is a straight path from a network position to code execution.
+    pushUpdateState({
+      status: 'error',
+      message: 'Ignoring QBZ_UPDATE_URL: only https update feeds are accepted.'
+    });
   }
 
   autoUpdater.autoDownload = true;
@@ -690,14 +726,29 @@ function registerIpc() {
   });
 
   ipcMain.handle('desktop:open-folder', async (event, folderPath) => {
-    if (!folderPath || !fs.existsSync(folderPath)) return false;
-    await shell.openPath(folderPath);
+    if (typeof folderPath !== 'string' || !folderPath) return false;
+
+    // shell.openPath on a file hands it to its registered application — which
+    // for a .app, .command or .desktop means launching it. Only ever open a
+    // directory in the file manager.
+    const resolved = path.resolve(folderPath);
+    let stat;
+    try {
+      stat = fs.statSync(resolved);
+    } catch {
+      return false;
+    }
+    if (!stat.isDirectory()) return false;
+
+    await shell.openPath(resolved);
     return true;
   });
 
   ipcMain.handle('desktop:show-item', async (event, filePath) => {
-    if (!filePath || !fs.existsSync(filePath)) return false;
-    shell.showItemInFolder(filePath);
+    if (typeof filePath !== 'string' || !filePath) return false;
+    // showItemInFolder only reveals the item, it never executes it.
+    if (!fs.existsSync(filePath)) return false;
+    shell.showItemInFolder(path.resolve(filePath));
     return true;
   });
 }

--- a/src/api/qobuz.ts
+++ b/src/api/qobuz.ts
@@ -159,7 +159,15 @@ export class QobuzAPI {
     private getBackoffDelayMs(error: AxiosError, attempt: number): number {
         const retryAfterMs = this.parseRetryAfterMs(error);
         if (error.response?.status === 429 && retryAfterMs !== null) {
-            return retryAfterMs;
+            if (retryAfterMs > this.maxBackoffMs) {
+                logger.warn(
+                    `Qobuz asked for a ${Math.round(retryAfterMs / 1000)}s pause; capping at ${Math.round(this.maxBackoffMs / 1000)}s`,
+                    'API'
+                );
+            }
+            // Uncapped, a single hostile or mistaken Retry-After stalls every
+            // Qobuz call for the lifetime of the process.
+            return Math.min(retryAfterMs, this.maxBackoffMs);
         }
 
         const baseDelay = Math.max(250, CONFIG.download.retryDelay ?? 1000);

--- a/src/services/ConfigBackupService.ts
+++ b/src/services/ConfigBackupService.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { z } from 'zod';
-import { settingsService } from './settings.js';
+import { settingsService, KNOWN_SETTING_KEYS } from './settings.js';
 import { databaseService } from './database/index.js';
 import { downloadQueue } from './queue/queue.js';
 
@@ -69,7 +69,14 @@ export class ConfigBackupService {
             databaseService.clearQueueItems();
         }
 
-        settingsService.setMany(settings);
+        // settingsService.setMany mirrors every key it is given into
+        // process.env, so an unfiltered import would let a crafted backup set
+        // NODE_TLS_REJECT_UNAUTHORIZED, PATH or QBZ_DESKTOP.
+        const knownKeys = KNOWN_SETTING_KEYS as readonly string[];
+        const allowedSettings = Object.fromEntries(
+            Object.entries(settings).filter(([key]) => knownKeys.includes(key))
+        );
+        settingsService.setMany(allowedSettings);
 
         for (const playlist of watchedPlaylists) {
             databaseService.upsertWatchedPlaylist({
@@ -121,7 +128,7 @@ export class ConfigBackupService {
         await downloadQueue.load();
 
         return {
-            settings: Object.keys(settings).length,
+            settings: Object.keys(allowedSettings).length,
             watchedPlaylists: watchedPlaylists.length,
             queueItems: queue.length
         };

--- a/src/services/FormatConverterService.ts
+++ b/src/services/FormatConverterService.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
 import { existsSync, mkdirSync, unlinkSync } from 'fs';
@@ -7,7 +7,21 @@ import { logger } from '../utils/logger.js';
 
 import { resolveBinaryPath, checkBinaryAvailability } from '../utils/binaries.js';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+/**
+ * EXPORT_FORMAT and EXPORT_BITRATE are free-form strings written through the
+ * settings API. They end up as ffmpeg arguments and as an output file
+ * extension, so both are constrained to a known set rather than trusted.
+ */
+const CODECS: Record<string, string> = {
+    mp3: 'libmp3lame',
+    aac: 'aac',
+    opus: 'libopus'
+};
+const DEFAULT_FORMAT = 'mp3';
+const ALLOWED_BITRATES = new Set(['96k', '128k', '160k', '192k', '256k', '320k']);
+const DEFAULT_BITRATE = '320k';
 
 export class FormatConverterService {
     async convert(inputPath: string): Promise<string | null> {
@@ -25,6 +39,24 @@ export class FormatConverterService {
             return null;
         }
 
+        const safeFormat = Object.prototype.hasOwnProperty.call(CODECS, format)
+            ? format
+            : DEFAULT_FORMAT;
+        const safeBitrate = ALLOWED_BITRATES.has(bitrate) ? bitrate : DEFAULT_BITRATE;
+
+        if (safeFormat !== format) {
+            logger.warn(
+                `Converter: unsupported EXPORT_FORMAT "${format}", falling back to ${DEFAULT_FORMAT}`,
+                'CONVERTER'
+            );
+        }
+        if (safeBitrate !== bitrate) {
+            logger.warn(
+                `Converter: unsupported EXPORT_BITRATE "${bitrate}", falling back to ${DEFAULT_BITRATE}`,
+                'CONVERTER'
+            );
+        }
+
         const baseName = path.basename(inputPath, '.flac');
         const dirName = path.dirname(inputPath);
         const finalOutputDir = outputDir || dirName;
@@ -33,23 +65,35 @@ export class FormatConverterService {
             mkdirSync(finalOutputDir, { recursive: true });
         }
 
-        const outputPath = path.join(finalOutputDir, `${baseName}.${format}`);
+        const outputPath = path.join(finalOutputDir, `${baseName}.${safeFormat}`);
         
         if (existsSync(outputPath)) {
             logger.debug(`Converter: Output file already exists, skipping: ${outputPath}`, 'CONVERTER');
             return outputPath;
         }
 
-        logger.info(`Converter: Exporting ${baseName} to ${format.toUpperCase()} (${bitrate})...`, 'CONVERTER');
+        logger.info(
+            `Converter: Exporting ${baseName} to ${safeFormat.toUpperCase()} (${safeBitrate})...`,
+            'CONVERTER'
+        );
 
         try {
-            let codec = 'libmp3lame';
-            if (format === 'aac') codec = 'aac';
-            if (format === 'opus') codec = 'libopus';
+            const codec = CODECS[safeFormat]!;
 
             const ffmpeg = resolveBinaryPath('ffmpeg');
-            const cmd = `"${ffmpeg}" -i "${inputPath}" -codec:a ${codec} -b:a ${bitrate} -map_metadata 0 "${outputPath}"`;
-            await execAsync(cmd);
+            // argv form, never a shell string: bitrate was interpolated
+            // unquoted, so a settings write was enough to append a command.
+            await execFileAsync(ffmpeg, [
+                '-i',
+                inputPath,
+                '-codec:a',
+                codec,
+                '-b:a',
+                safeBitrate,
+                '-map_metadata',
+                '0',
+                outputPath
+            ]);
 
             logger.success(`Converter: Export complete: ${path.basename(outputPath)}`, 'CONVERTER');
 

--- a/src/services/MediaServerService.ts
+++ b/src/services/MediaServerService.ts
@@ -2,6 +2,25 @@ import axios from 'axios';
 import { CONFIG } from '../config.js';
 import { logger } from '../utils/logger.js';
 
+/** These calls sit on the download completion path; without a bound a
+ *  unresponsive media server stalls the whole pipeline. */
+const NOTIFY_TIMEOUT_MS = 10000;
+
+/** Reject anything that is not plain HTTP(S) before it reaches axios, so a
+ *  media-server URL cannot become a file:// or other protocol handler read. */
+function assertHttpUrl(url: string): void {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new Error('Media server URL is not a valid URL');
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new Error('Media server URL must use http or https');
+    }
+}
+
 export class MediaServerService {
     async notifyNewContent(data: {
         title: string;
@@ -19,6 +38,8 @@ export class MediaServerService {
         logger.info(`MediaServer: Notifying ${type} about new content: ${data.title}`, 'MEDIA');
 
         try {
+            assertHttpUrl(url);
+
             switch (type) {
                 case 'plex':
                     await this.notifyPlex(url, token, libraryId);
@@ -38,39 +59,58 @@ export class MediaServerService {
 
     private async notifyPlex(url: string, token: string, libraryId?: string) {
         const section = libraryId || 'all';
-        const endpoint = `${url}/library/sections/${section}/refresh?X-Plex-Token=${token}`;
-        await axios.get(endpoint);
+        // Plex authenticates by token; keep it in a header rather than the
+        // query string so it does not land in the server's access log.
+        const endpoint = `${url}/library/sections/${encodeURIComponent(section)}/refresh`;
+        await axios.get(endpoint, {
+            timeout: NOTIFY_TIMEOUT_MS,
+            headers: { 'X-Plex-Token': token }
+        });
         logger.success('MediaServer: Plex library scan triggered.', 'MEDIA');
     }
 
     private async notifyJellyfin(url: string, token: string) {
-        const endpoint = `${url}/Library/Refresh?api_key=${token}`;
-        await axios.post(endpoint);
+        const endpoint = `${url}/Library/Refresh`;
+        await axios.post(endpoint, undefined, {
+            timeout: NOTIFY_TIMEOUT_MS,
+            headers: { 'X-Emby-Token': token }
+        });
         logger.success('MediaServer: Jellyfin library scan triggered.', 'MEDIA');
     }
 
     private async notifyWebhook(url: string, data: { title: string; artist: string; album: string; type: string }) {
-        await axios.post(url, {
-            event: 'download_complete',
-            timestamp: new Date().toISOString(),
-            payload: data
-        });
+        await axios.post(
+            url,
+            {
+                event: 'download_complete',
+                timestamp: new Date().toISOString(),
+                payload: data
+            },
+            { timeout: NOTIFY_TIMEOUT_MS }
+        );
         logger.success('MediaServer: Webhook notification sent.', 'MEDIA');
     }
 
     async testConnection(type: string, url: string, token: string, _libraryId?: string) {
         if (!url) throw new Error('URL is required');
+        assertHttpUrl(url);
 
         try {
             switch (type) {
                 case 'plex': {
-                    const plexEndpoint = `${url}/identity?X-Plex-Token=${token}`;
-                    await axios.get(plexEndpoint, { timeout: 5000 });
+                    const plexEndpoint = `${url}/identity`;
+                    await axios.get(plexEndpoint, {
+                        timeout: 5000,
+                        headers: { 'X-Plex-Token': token }
+                    });
                     return { success: true, message: 'Connected to Plex successfully' };
                 }
                 case 'jellyfin': {
-                    const jellyEndpoint = `${url}/System/Info?api_key=${token}`;
-                    await axios.get(jellyEndpoint, { timeout: 5000 });
+                    const jellyEndpoint = `${url}/System/Info`;
+                    await axios.get(jellyEndpoint, {
+                        timeout: 5000,
+                        headers: { 'X-Emby-Token': token }
+                    });
                     return { success: true, message: 'Connected to Jellyfin successfully' };
                 }
                 case 'webhook':

--- a/src/services/QualityScannerWorker.ts
+++ b/src/services/QualityScannerWorker.ts
@@ -1,4 +1,4 @@
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { parentPort, workerData } from 'node:worker_threads';
@@ -7,7 +7,7 @@ import { checkBinaryAvailability, resolveBinaryPath } from '../utils/binaries.js
 import { logger } from '../utils/logger.js';
 import type { QualityReport } from './QualityScannerService.js';
 
-const execPromise = promisify(exec);
+const execFilePromise = promisify(execFile);
 
 export function parseMeanVolume(output: string): number {
     const match = output.match(/mean_volume: ([-\d.]+) dB/);
@@ -38,15 +38,28 @@ export async function scanQualityFile(filePath: string): Promise<QualityReport> 
         }
 
         const ffmpeg = resolveBinaryPath('ffmpeg');
-        const cmd16 = `"${ffmpeg}" -v error -i "${filePath}" -af "highpass=f=16000, volumedetect" -f null -`;
-        const cmd20 = `"${ffmpeg}" -v error -i "${filePath}" -af "highpass=f=20000, volumedetect" -f null -`;
+        // argv form, never a shell string. filePath is derived from remote
+        // Qobuz metadata via the filename template, and sanitizeFilename leaves
+        // `$`, backticks and `;` intact — inside a double-quoted shell word
+        // those still expand.
+        const ffmpegArgs = (cutoffHz: number): string[] => [
+            '-v',
+            'error',
+            '-i',
+            filePath,
+            '-af',
+            `highpass=f=${cutoffHz}, volumedetect`,
+            '-f',
+            'null',
+            '-'
+        ];
 
         const [result16, result20] = await Promise.all([
-            execPromise(cmd16).catch((error) => {
+            execFilePromise(ffmpeg, ffmpegArgs(16000)).catch((error) => {
                 logger.debug(`FFmpeg 16k error: ${error.message}`);
                 return { stderr: error.stderr || '' };
             }),
-            execPromise(cmd20).catch((error) => {
+            execFilePromise(ffmpeg, ffmpegArgs(20000)).catch((error) => {
                 logger.debug(`FFmpeg 20k error: ${error.message}`);
                 return { stderr: error.stderr || '' };
             })

--- a/src/services/config-backup.test.ts
+++ b/src/services/config-backup.test.ts
@@ -8,7 +8,8 @@ vi.mock('./settings.js', () => ({
     settingsService: {
         getAll: vi.fn(),
         setMany: vi.fn()
-    }
+    },
+    KNOWN_SETTING_KEYS: ['QOBUZ_APP_ID', 'UI_LANGUAGE']
 }));
 
 vi.mock('./database/index.js', () => ({

--- a/src/services/dashboard/index.test.ts
+++ b/src/services/dashboard/index.test.ts
@@ -61,8 +61,11 @@ vi.mock('./routes.js', () => ({
 }));
 
 import { AddressInfo } from 'net';
+import { Server } from 'http';
+import request from 'supertest';
 import { DashboardService, dashboardService } from './index.js';
 import { logger } from '../../utils/logger.js';
+import { CONFIG } from '../../config.js';
 
 const services: DashboardService[] = [];
 
@@ -76,11 +79,26 @@ function getPort(service: DashboardService): number {
     return server.address().port;
 }
 
+function getServer(service: DashboardService): Server {
+    return (service as unknown as { httpServer: Server }).httpServer;
+}
+
+async function startService(): Promise<DashboardService> {
+    const service = new DashboardService(0);
+    services.push(service);
+    const listening = waitForListening(service);
+    service.start();
+    await listening;
+    return service;
+}
+
 afterEach(() => {
     for (const service of services.splice(0)) {
         service.stop();
     }
     dashboardService.stop();
+    CONFIG.dashboard.password = '';
+    delete process.env.QBZ_DESKTOP;
     vi.clearAllMocks();
 });
 
@@ -103,5 +121,85 @@ describe('DashboardService', () => {
                 'WEB'
             );
         });
+    });
+});
+
+describe('DashboardService password guard', () => {
+    /**
+     * Express matches routes case-insensitively by default. The guard compared
+     * the raw path, so `/API/...` failed the "is this protected?" test, fell
+     * through unauthenticated, and was then dispatched to the very router the
+     * guard existed to protect.
+     */
+    it.each(['/api/logs', '/API/logs', '/Api/logs', '/aPi/logs', '/DOWNLOADS/x.flac'])(
+        'refuses %s without the password',
+        async (routePath) => {
+            CONFIG.dashboard.password = 'hunter2';
+            const service = await startService();
+
+            const response = await request(getServer(service)).get(routePath);
+
+            expect(response.status).toBe(401);
+        }
+    );
+
+    it('accepts the password in the x-password header', async () => {
+        CONFIG.dashboard.password = 'hunter2';
+        const service = await startService();
+
+        // registerRoutes is mocked out, so a permitted request falls through to
+        // the catch-all, which answers 404 for /api paths. Anything other than
+        // 401 proves the guard let it past.
+        const response = await request(getServer(service))
+            .get('/api/logs')
+            .set('x-password', 'hunter2');
+
+        expect(response.status).toBe(404);
+    });
+
+    it('no longer accepts the password in the query string', async () => {
+        CONFIG.dashboard.password = 'hunter2';
+        const service = await startService();
+
+        const response = await request(getServer(service)).get('/api/logs?pw=hunter2');
+
+        expect(response.status).toBe(401);
+    });
+
+    it('leaves theme reads unauthenticated but not theme writes', async () => {
+        CONFIG.dashboard.password = 'hunter2';
+        const service = await startService();
+
+        const read = await request(getServer(service)).get('/api/themes');
+        expect(read.status).toBe(404); // past the guard, no route registered
+
+        const write = await request(getServer(service)).post('/api/themes').send({});
+        expect(write.status).toBe(401);
+    });
+
+    it('rejects a cross-origin state-changing request', async () => {
+        CONFIG.dashboard.password = 'hunter2';
+        const service = await startService();
+
+        const response = await request(getServer(service))
+            .post('/api/settings')
+            .set('x-password', 'hunter2')
+            .set('Origin', 'https://evil.example')
+            .send({});
+
+        expect(response.status).toBe(403);
+    });
+
+    it('rejects a non-loopback Host header when nothing else authenticates', async () => {
+        CONFIG.dashboard.password = '';
+        const service = await startService();
+
+        const rebound = await request(getServer(service))
+            .get('/api/status')
+            .set('Host', 'evil.example');
+        expect(rebound.status).toBe(403);
+
+        const local = await request(getServer(service)).get('/api/status');
+        expect(local.status).not.toBe(403);
     });
 });

--- a/src/services/dashboard/index.ts
+++ b/src/services/dashboard/index.ts
@@ -79,14 +79,35 @@ export class DashboardService {
     private io: SocketServer;
     private port: number;
     private checkInterval: NodeJS.Timeout | null = null;
+    /** The address actually passed to listen(), which start() may downgrade. */
+    private boundHost: string = CONFIG.dashboard.host || '127.0.0.1';
 
     constructor(port: number = CONFIG.dashboard.port || 3000) {
         this.port = port;
         this.app = express();
+        // Express matches routes case-insensitively by default, so `/API/logs`
+        // reaches the same router as `/api/logs`. The auth guard below decides
+        // what is protected from the same path, and the two must never disagree.
+        this.app.set('case sensitive routing', true);
         this.httpServer = createServer(this.app);
         this.io = new SocketServer(this.httpServer, {
             transports: ['websocket', 'polling'],
-            allowEIO3: true
+            allowEIO3: true,
+            // A WebSocket upgrade is not subject to the same-origin policy and
+            // socket.io only installs CORS when `cors` is set, so without this
+            // any page the user visits could open a socket and receive the live
+            // log, queue and notification streams. Clients that send no Origin
+            // (CLI, tests) are unaffected.
+            allowRequest: (req, callback) => {
+                const origin = req.headers.origin;
+                if (!origin) return callback(null, true);
+
+                try {
+                    callback(null, new URL(origin).host === req.headers.host);
+                } catch {
+                    callback(null, false);
+                }
+            }
         });
 
 
@@ -96,7 +117,60 @@ export class DashboardService {
     }
 
     private setupMiddleware(): void {
+        // DNS rebinding guard. A loopback bind is only private as long as the
+        // browser agrees the request is cross-origin; an attacker who points
+        // their own hostname at 127.0.0.1 makes the app same-origin to their
+        // page and can then read every response. Only enforced when the bind is
+        // loopback AND nothing else authenticates the caller, so a reverse
+        // proxy fronting a password-protected instance keeps working.
+        this.app.use((req: Request, res: Response, next: NextFunction) => {
+            if (!this.requiresLoopbackHost()) return next();
+
+            const hostHeader = req.headers.host || '';
+            const hostname = hostHeader.replace(/:\d+$/, '');
+            if (!hostname || DashboardService.isLoopbackHost(hostname)) return next();
+
+            logger.warn(`Rejected request with non-loopback Host header: ${hostHeader}`, 'SECURITY');
+            res.status(403).json({ error: 'Forbidden: invalid Host header' });
+        });
+
+        // CSRF guard. `express.urlencoded` makes a cross-origin form POST a
+        // CORS "simple request" — no preflight — so without this any page the
+        // user visits can drive every state-changing route, and in desktop mode
+        // the password middleware below is bypassed entirely.
+        this.app.use((req: Request, res: Response, next: NextFunction) => {
+            if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') {
+                return next();
+            }
+
+            const origin = req.headers.origin;
+            if (!origin) return next(); // non-browser clients never send Origin
+
+            let originHost: string;
+            try {
+                originHost = new URL(origin).host;
+            } catch {
+                res.status(403).json({ error: 'Forbidden: malformed Origin header' });
+                return;
+            }
+
+            if (originHost !== req.headers.host) {
+                logger.warn(`Rejected cross-origin ${req.method} from ${origin}`, 'SECURITY');
+                res.status(403).json({ error: 'Forbidden: cross-origin request' });
+                return;
+            }
+
+            next();
+        });
+
         this.app.use((_req: Request, res: Response, next: NextFunction) => {
+            // Lets the Electron shell confirm the loopback port is served by
+            // the backend it just started, and not by a local process that won
+            // the race for the port.
+            if (process.env.QBZ_DESKTOP_TOKEN) {
+                res.setHeader('X-QBZ-Desktop-Token', process.env.QBZ_DESKTOP_TOKEN);
+            }
+
             res.setHeader(
                 'Content-Security-Policy',
                 "default-src 'self'; " +
@@ -123,6 +197,19 @@ export class DashboardService {
 
         this.app.use('/api', limiter);
 
+        // The generic limiter allows ~96k attempts a day, which is not a
+        // meaningful bound on guessing a dashboard password.
+        const authLimiter = rateLimit({
+            windowMs: 15 * 60 * 1000,
+            max: 20,
+            message: { error: 'Too many authentication attempts, please try again later' },
+            standardHeaders: true,
+            legacyHeaders: false,
+            skipSuccessfulRequests: true
+        });
+
+        this.app.use(['/api/auth/verify', '/api/login'], authLimiter);
+
         this.app.get('/api/auth/verify', (req: Request, res: Response) => {
             const password = CONFIG.dashboard.password;
             const isDesktop = process.env.QBZ_DESKTOP === '1';
@@ -132,7 +219,7 @@ export class DashboardService {
                 return;
             }
 
-            const providedPassword = req.headers['x-password'] || req.query.pw;
+            const providedPassword = req.headers['x-password'];
             if (
                 providedPassword &&
                 typeof providedPassword === 'string' &&
@@ -165,20 +252,36 @@ export class DashboardService {
             // exempting them left every track readable to anyone who could reach
             // the port, which matters the moment the dashboard is put behind a
             // domain rather than kept on a LAN.
-            const excludedRoutes = [
-                '/api/status',
-                '/api/themes',
-                '/api/onboarding'
-            ];
+            //
+            // /api/themes is read-only here: POST /api/themes and
+            // DELETE /api/themes/:id mutate stored themes and must stay behind
+            // the password.
+            const excludedRoutes = ['/api/status', '/api/onboarding'];
+            const readOnlyExcludedRoutes = ['/api/themes'];
 
-            const isExcluded = excludedRoutes.some((route) => req.path.startsWith(route));
+            // Express route matching is case-insensitive unless configured
+            // otherwise, so this test has to be too — comparing the raw path
+            // let `/API/...` slip past the guard and still reach the router.
+            const requestPath = req.path.toLowerCase();
+            const isReadRequest = req.method === 'GET' || req.method === 'HEAD';
+
+            // Exact or whole-segment match only, so a future `/api/statuses`
+            // route cannot inherit the `/api/status` exemption.
+            const matchesRoute = (route: string): boolean =>
+                requestPath === route || requestPath.startsWith(`${route}/`);
+
+            const isExcluded =
+                excludedRoutes.some(matchesRoute) ||
+                (isReadRequest && readOnlyExcludedRoutes.some(matchesRoute));
             if (isExcluded) return next();
 
-            const isProtected = req.path.startsWith('/api') || req.path.startsWith('/downloads');
+            const isProtected =
+                requestPath.startsWith('/api') || requestPath.startsWith('/downloads');
             if (!isProtected) return next();
 
-            const providedPassword =
-                req.headers['x-password'] || req.query.pw || readSessionCookie(req);
+            // Deliberately not accepting the password from the query string: it
+            // lands in access logs, Referer headers and browser history.
+            const providedPassword = req.headers['x-password'] || readSessionCookie(req);
 
             if (
                 providedPassword &&
@@ -211,7 +314,9 @@ export class DashboardService {
         registerRoutes(this.app);
 
         this.app.get(/.*/, (req: Request, res: Response) => {
-            const isProtected = req.path.startsWith('/api') || req.path.startsWith('/downloads');
+            const requestPath = req.path.toLowerCase();
+            const isProtected =
+                requestPath.startsWith('/api') || requestPath.startsWith('/downloads');
             if (isProtected) {
                 return res.status(404).json({ error: 'Endpoint not found' });
             }
@@ -227,7 +332,7 @@ export class DashboardService {
             // Bypass password protection entirely in Desktop mode
             if (!password || isDesktop) return next();
 
-            const providedPassword = socket.handshake.auth?.password || socket.handshake.query?.pw;
+            const providedPassword = socket.handshake.auth?.password;
 
             if (providedPassword && typeof providedPassword === 'string' && password) {
                 try {
@@ -332,6 +437,16 @@ export class DashboardService {
         });
     }
 
+    /**
+     * True when the only thing keeping the API private is the loopback bind —
+     * i.e. no password will be demanded from the caller. Those are exactly the
+     * deployments a DNS-rebinding attack turns into a same-origin API.
+     */
+    private requiresLoopbackHost(): boolean {
+        if (!DashboardService.isLoopbackHost(this.boundHost)) return false;
+        return process.env.QBZ_DESKTOP === '1' || !CONFIG.dashboard.password;
+    }
+
     /** Loopback binds are reachable from this machine alone. */
     private static isLoopbackHost(host: string): boolean {
         const normalized = host.trim().toLowerCase().replace(/^\[|\]$/g, '');
@@ -359,6 +474,8 @@ export class DashboardService {
             );
             host = '127.0.0.1';
         }
+
+        this.boundHost = host;
 
         this.httpServer.once('error', (error) => {
             const message = error instanceof Error ? error.message : String(error);

--- a/src/services/dashboard/routers/catalog.routes.ts
+++ b/src/services/dashboard/routers/catalog.routes.ts
@@ -218,7 +218,9 @@ router.get('/stream/:id', async (req: Request, res: Response) => {
         const url = await audioPreviewService.getStreamUrl(trackId);
 
         if (url) {
-            res.setHeader('Access-Control-Allow-Origin', '*');
+            // No Access-Control-Allow-Origin here: the dashboard plays this
+            // from its own origin, and `*` let any site read a signed Qobuz
+            // stream URL minted with the user's credentials.
             res.redirect(url);
         } else {
             res.status(404).json({ error: 'Stream URL not found' });

--- a/src/services/dashboard/routers/library.routes.ts
+++ b/src/services/dashboard/routers/library.routes.ts
@@ -6,10 +6,23 @@ import { CONFIG } from '../../../config.js';
 import { formatConverterService } from '../../FormatConverterService.js';
 import { logger } from '../../../utils/logger.js';
 import { isPathWithinManagedRoots } from '../../../utils/paths.js';
+import { isPublicHttpUrl, MAX_IMAGE_BYTES, MAX_IMAGE_REDIRECTS } from '../../../utils/net.js';
 
 const router = Router();
 
 const getParam = (p: unknown): string => (Array.isArray(p) ? String(p[0]) : String(p ?? ''));
+
+/**
+ * Pagination values reach SQLite's LIMIT/OFFSET directly, and SQLite reads a
+ * negative LIMIT as "no limit" — so `?limit=-1` dumped whole tables.
+ */
+const getPageParam = (raw: unknown, fallback: number, max: number): number => {
+    const parsed = parseInt(getParam(raw), 10);
+    if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+    return Math.min(parsed, max);
+};
+
+const MAX_PAGE_SIZE = 1000;
 
 router.get('/scan/status', async (req: Request, res: Response) => {
     const stats = libraryScannerService.getScanStats();
@@ -23,7 +36,23 @@ router.get('/scan/status', async (req: Request, res: Response) => {
 
 router.post('/scan', (req: Request, res: Response) => {
     const { path } = req.body;
-    libraryScannerService.scanLibrary(path);
+
+    // Without this the caller picks any directory and the scanner walks it into
+    // the database, which the /api/library/files route then reads back.
+    if (path !== undefined && !isPathWithinManagedRoots(path)) {
+        logger.warn(`Refused library scan outside the library: ${path}`, 'LIBRARY');
+        res.status(403).json({ error: 'Path is outside the library directory' });
+        return;
+    }
+
+    // scanLibrary rejects with 'Scan already in progress'; unhandled, that
+    // rejection terminates the process on Node 20+.
+    libraryScannerService
+        .scanLibrary(path)
+        .catch((error: unknown) =>
+            logger.error(`Library scan failed: ${(error as Error).message}`, 'LIBRARY')
+        );
+
     res.json({ success: true });
 });
 
@@ -43,8 +72,8 @@ router.get('/statistics', async (req: Request, res: Response) => {
 
 router.get('/files', (req: Request, res: Response) => {
     try {
-        const limit = parseInt(getParam(req.query.limit)) || 100;
-        const offset = parseInt(getParam(req.query.offset)) || 0;
+        const limit = getPageParam(req.query.limit, 100, MAX_PAGE_SIZE);
+        const offset = getPageParam(req.query.offset, 0, Number.MAX_SAFE_INTEGER);
         const files = databaseService.getLibraryFiles(limit, offset);
         res.json(files);
     } catch (error: unknown) {
@@ -171,10 +200,24 @@ router.post('/metadata/edit', async (req: Request, res: Response) => {
             const axios = (await import('axios')).default;
             const { logger } = await import('../../../utils/logger.js');
             for (const candidate of coverCandidates) {
+                // The URL comes from the request body, so it must not be used
+                // to reach the host's own network.
+                if (!isPublicHttpUrl(candidate)) {
+                    logger.warn(`Refused cover fetch for non-public URL: ${candidate}`, 'METADATA');
+                    continue;
+                }
+
                 try {
                     const response = await axios.get(candidate, {
                         responseType: 'arraybuffer',
-                        timeout: 15000
+                        timeout: 15000,
+                        maxContentLength: MAX_IMAGE_BYTES,
+                        maxRedirects: MAX_IMAGE_REDIRECTS,
+                        beforeRedirect: (options) => {
+                            if (!isPublicHttpUrl(options.href)) {
+                                throw new Error('redirect to a non-public host');
+                            }
+                        }
                     });
                     coverBuffer = Buffer.from(response.data);
                     break;
@@ -233,8 +276,8 @@ router.get('/database/stats', async (req: Request, res: Response) => {
 
 router.get('/database/tracks', async (req: Request, res: Response) => {
     try {
-        const limit = parseInt(req.query.limit as string) || 100;
-        const offset = parseInt(req.query.offset as string) || 0;
+        const limit = getPageParam(req.query.limit, 100, MAX_PAGE_SIZE);
+        const offset = getPageParam(req.query.offset, 0, Number.MAX_SAFE_INTEGER);
         res.json(databaseService.getAllTracks(limit, offset));
     } catch (error: unknown) {
         res.status(500).json({ error: (error as Error).message });
@@ -243,8 +286,8 @@ router.get('/database/tracks', async (req: Request, res: Response) => {
 
 router.get('/database/albums', async (req: Request, res: Response) => {
     try {
-        const limit = parseInt(req.query.limit as string) || 50;
-        const offset = parseInt(req.query.offset as string) || 0;
+        const limit = getPageParam(req.query.limit, 50, MAX_PAGE_SIZE);
+        const offset = getPageParam(req.query.offset, 0, Number.MAX_SAFE_INTEGER);
         res.json(databaseService.getAllAlbums(limit, offset));
     } catch (error: unknown) {
         res.status(500).json({ error: (error as Error).message });

--- a/src/services/dashboard/routers/tools.routes.ts
+++ b/src/services/dashboard/routers/tools.routes.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import axios from 'axios';
 import { logger } from '../../../utils/logger.js';
 import { isPathWithinManagedRoots } from '../../../utils/paths.js';
+import { isPublicHttpUrl, MAX_IMAGE_BYTES, MAX_IMAGE_REDIRECTS } from '../../../utils/net.js';
 import { CONFIG } from '../../../config.js';
 import { databaseService } from '../../database/index.js';
 import {
@@ -190,10 +191,24 @@ router.post('/apply-metadata', async (req: Request, res: Response) => {
         );
 
         for (const imageUrl of coverCandidates) {
+            // The URL comes from the request body, so it must not be used to
+            // reach the host's own network.
+            if (!isPublicHttpUrl(imageUrl)) {
+                logger.warn(`Refused cover fetch for non-public URL: ${imageUrl}`, 'TOOLS');
+                continue;
+            }
+
             try {
                 const response = await axios.get(imageUrl, {
                     responseType: 'arraybuffer',
-                    timeout: 15000
+                    timeout: 15000,
+                    maxContentLength: MAX_IMAGE_BYTES,
+                    maxRedirects: MAX_IMAGE_REDIRECTS,
+                    beforeRedirect: (options) => {
+                        if (!isPublicHttpUrl(options.href)) {
+                            throw new Error('redirect to a non-public host');
+                        }
+                    }
                 });
                 coverBuffer = Buffer.from(response.data);
                 break;

--- a/src/services/database/index.ts
+++ b/src/services/database/index.ts
@@ -7,6 +7,14 @@ import { logger } from '../../utils/logger.js';
 const DB_VERSION = 12;
 const DEFAULT_DB_PATH = path.resolve(process.cwd(), 'data', 'qbz.db');
 
+/**
+ * `%` and `_` are wildcards inside a LIKE pattern. A search for "100_" or a
+ * filename containing "%" otherwise matches rows it should not — which for
+ * deleteTrackByPath means removing the wrong track.
+ * Callers must pair this with `ESCAPE '\'` in the statement.
+ */
+const escapeLikePattern = (value: string): string => value.replace(/[\\%_]/g, (c) => `\\${c}`);
+
 export interface DbTrack {
     id: string;
     title: string;
@@ -681,10 +689,10 @@ export class DatabaseService {
 
     searchTracks(query: string): DbTrack[] {
         const db = this.getDb();
-        const searchQuery = `%${query}%`;
+        const searchQuery = `%${escapeLikePattern(query)}%`;
         return db
             .prepare(
-                'SELECT * FROM tracks WHERE title LIKE ? OR artist LIKE ? OR album LIKE ? ORDER BY downloaded_at DESC LIMIT 100'
+                "SELECT * FROM tracks WHERE title LIKE ? ESCAPE '\\' OR artist LIKE ? ESCAPE '\\' OR album LIKE ? ESCAPE '\\' ORDER BY downloaded_at DESC LIMIT 100"
             )
             .all(searchQuery, searchQuery, searchQuery) as DbTrack[];
     }
@@ -1231,8 +1239,10 @@ export class DatabaseService {
             const suffixWin = `\\${parentDir}\\${filename}`;
 
             track = db
-                .prepare('SELECT * FROM tracks WHERE file_path LIKE ? OR file_path LIKE ?')
-                .get(`%${suffixUnix}`, `%${suffixWin}`) as { file_path: string; album_artist?: string; artist?: string; quality?: number; file_size?: number; genre?: string } | undefined;
+                .prepare(
+                    "SELECT * FROM tracks WHERE file_path LIKE ? ESCAPE '\\' OR file_path LIKE ? ESCAPE '\\'"
+                )
+                .get(`%${escapeLikePattern(suffixUnix)}`, `%${escapeLikePattern(suffixWin)}`) as { file_path: string; album_artist?: string; artist?: string; quality?: number; file_size?: number; genre?: string } | undefined;
         }
 
         if (track) {
@@ -1601,11 +1611,12 @@ export class DatabaseService {
 
     searchHistory(query: string): Record<string, unknown>[] {
         const db = this.getDb();
-        const searchQuery = `%${query}%`;
+        const searchQuery = `%${escapeLikePattern(query)}%`;
         const rows = db.prepare(`
-            SELECT * FROM history 
-            WHERE title LIKE ? OR artist LIKE ? OR album LIKE ? 
+            SELECT * FROM history
+            WHERE title LIKE ? ESCAPE '\\' OR artist LIKE ? ESCAPE '\\' OR album LIKE ? ESCAPE '\\'
             ORDER BY downloaded_at DESC
+            LIMIT 100
         `).all(searchQuery, searchQuery, searchQuery) as {
             downloaded_at?: string;
             artist_image_url?: string;

--- a/src/services/download.ts
+++ b/src/services/download.ts
@@ -18,6 +18,7 @@ import { mediaServerService } from './MediaServerService.js';
 import { formatConverterService } from './FormatConverterService.js';
 import { aiMetadataService } from './AIMetadataService.js';
 import { globalApiLimit } from '../utils/limit.js';
+import { MAX_IMAGE_BYTES, MAX_IMAGE_REDIRECTS } from '../utils/net.js';
 
 export { DownloadProgress };
 
@@ -185,7 +186,11 @@ export default class DownloadService {
             try {
                 const response = await axios.get(url, {
                     responseType: 'arraybuffer',
-                    timeout: 15000
+                    timeout: 15000,
+                    // The URL comes from remote Qobuz metadata; without a cap
+                    // a hostile response buffers until the process dies.
+                    maxContentLength: MAX_IMAGE_BYTES,
+                    maxRedirects: MAX_IMAGE_REDIRECTS
                 });
                 const contentType = String(response.headers?.['content-type'] || '');
                 const buffer = Buffer.from(response.data);

--- a/src/services/format-converter.test.ts
+++ b/src/services/format-converter.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { FormatConverterService } from './FormatConverterService.js';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import * as fs from 'fs';
 import { checkBinaryAvailability } from '../utils/binaries.js';
 import { CONFIG } from '../config.js';
 
 // Mock dependencies
+// execFile, not exec: the converter builds an argv array so a settings value
+// such as EXPORT_BITRATE can never reach a shell.
 vi.mock('child_process', () => ({
-    exec: vi.fn((cmd, cb) => cb(null, { stdout: '', stderr: '' }))
+    execFile: vi.fn((file, args, cb) => cb(null, { stdout: '', stderr: '' }))
 }));
 
 vi.mock('fs', () => {
@@ -76,7 +78,7 @@ describe('FormatConverterService', () => {
         
         expect(result).toBeDefined();
         expect(result).toContain('input.mp3');
-        expect(exec).toHaveBeenCalled();
+        expect(execFile).toHaveBeenCalled();
     });
 
     it('should remove original file if keepOriginal is false', async () => {
@@ -89,7 +91,7 @@ describe('FormatConverterService', () => {
     it('should skip if output file already exists', async () => {
         vi.mocked(fs.existsSync).mockReturnValue(true);
         const result = await service.convert('input.flac');
-        expect(exec).not.toHaveBeenCalled();
+        expect(execFile).not.toHaveBeenCalled();
         expect(result).toBeDefined();
     });
 

--- a/src/services/library-scanner/worker.ts
+++ b/src/services/library-scanner/worker.ts
@@ -2,7 +2,7 @@ import { parentPort } from 'worker_threads';
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { parseFile } from 'music-metadata';
 import type { IAudioMetadata } from 'music-metadata';
 
@@ -11,7 +11,10 @@ import { resolveBinaryPath } from '../../utils/binaries.js';
 function getAudioFingerprint(filePath: string): string | undefined {
     try {
         const fpcalc = resolveBinaryPath('fpcalc');
-        const stdout = execSync(`"${fpcalc}" -json "${filePath}"`, {
+        // argv form, never a shell string: a filename may legally contain `"`,
+        // `$`, backticks or `;`, and building a command line out of one hands
+        // the shell whatever the file is called.
+        const stdout = execFileSync(fpcalc, ['-json', filePath], {
             encoding: 'utf-8',
             stdio: ['ignore', 'pipe', 'ignore']
         });

--- a/src/services/media-server.test.ts
+++ b/src/services/media-server.test.ts
@@ -49,8 +49,13 @@ describe('MediaServerService', () => {
             });
 
             await service.notifyNewContent({ title: 'T', artist: 'A', album: 'Alb', type: 'track' });
-            expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('refresh'));
-            expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('X-Plex-Token=token123'));
+            // The token goes in a header, not the query string, so it does not
+            // land in the media server's access log.
+            expect(axios.get).toHaveBeenCalledWith(
+                expect.stringContaining('refresh'),
+                expect.objectContaining({ headers: { 'X-Plex-Token': 'token123' } })
+            );
+            expect(vi.mocked(axios.get).mock.calls[0]?.[0]).not.toContain('token123');
         });
 
         it('should notify Jellyfin', async () => {
@@ -63,7 +68,12 @@ describe('MediaServerService', () => {
             });
 
             await service.notifyNewContent({ title: 'T', artist: 'A', album: 'Alb', type: 'track' });
-            expect(axios.post).toHaveBeenCalledWith(expect.stringContaining('Refresh?api_key=jkey'));
+            expect(axios.post).toHaveBeenCalledWith(
+                expect.stringContaining('/Library/Refresh'),
+                undefined,
+                expect.objectContaining({ headers: { 'X-Emby-Token': 'jkey' } })
+            );
+            expect(vi.mocked(axios.post).mock.calls[0]?.[0]).not.toContain('jkey');
         });
 
         it('should notify Webhook', async () => {
@@ -75,9 +85,27 @@ describe('MediaServerService', () => {
             });
 
             await service.notifyNewContent({ title: 'T', artist: 'A', album: 'Alb', type: 'track' });
-            expect(axios.post).toHaveBeenCalledWith('http://hook', expect.objectContaining({
-                event: 'download_complete'
-            }));
+            expect(axios.post).toHaveBeenCalledWith(
+                'http://hook',
+                expect.objectContaining({ event: 'download_complete' }),
+                expect.objectContaining({ timeout: expect.any(Number) })
+            );
+        });
+
+        it('should refuse a media server URL that is not http(s)', async () => {
+            vi.mocked(settingsService.get).mockImplementation((key) => {
+                if (key === 'MEDIA_SERVER_ENABLED') return 'true';
+                if (key === 'MEDIA_SERVER_TYPE') return 'webhook';
+                if (key === 'MEDIA_SERVER_URL') return 'file:///etc/passwd';
+                return '';
+            });
+
+            await service.notifyNewContent({ title: 'T', artist: 'A', album: 'Alb', type: 'track' });
+            expect(axios.post).not.toHaveBeenCalled();
+
+            await expect(
+                service.testConnection('webhook', 'file:///etc/passwd', '')
+            ).rejects.toThrow('must use http or https');
         });
     });
 

--- a/src/services/quality-scanner.test.ts
+++ b/src/services/quality-scanner.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { QualityScannerService } from './QualityScannerService.js';
 import { parseMeanVolume, scanQualityFile } from './QualityScannerWorker.js';
 import { checkBinaryAvailability } from '../utils/binaries.js';
 
 type ExecMockCallback = (err: Error | null, result: { stderr: string }) => void;
+
+/** The scanner passes ffmpeg an argv array, so the filter frequency arrives as
+ *  its own argument rather than embedded in a shell command string. */
+const hasFilter = (args: string[], needle: string): boolean =>
+    args.some((arg) => arg.includes(needle));
 
 const { workerState } = vi.hoisted(() => ({
     workerState: {
@@ -43,9 +48,9 @@ vi.mock('node:worker_threads', () => {
 });
 
 vi.mock('node:child_process', () => ({
-    exec: vi.fn((cmd: string, cb?: ExecMockCallback) => {
+    execFile: vi.fn((file: string, args: string[], cb?: ExecMockCallback) => {
         if (cb) cb(null, { stderr: 'mean_volume: -50.0 dB' });
-        return { on: vi.fn() } as unknown as ReturnType<typeof exec>;
+        return { on: vi.fn() } as unknown as ReturnType<typeof execFile>;
     })
 }));
 
@@ -92,10 +97,14 @@ describe('QualityScannerService', () => {
     });
 
     it('should identify true lossless files', async () => {
-        vi.mocked(exec).mockImplementation(((cmd: string, cb?: ExecMockCallback) => {
+        vi.mocked(execFile).mockImplementation(((
+            _file: string,
+            _args: string[],
+            cb?: ExecMockCallback
+        ) => {
             if (cb) cb(null, { stderr: 'mean_volume: -30.0 dB' });
-            return { on: vi.fn() } as unknown as ReturnType<typeof exec>;
-        }) as unknown as typeof exec);
+            return { on: vi.fn() } as unknown as ReturnType<typeof execFile>;
+        }) as unknown as typeof execFile);
 
         const report = await scanQualityFile('test.flac');
         expect(report.isTrueLossless).toBe(true);
@@ -103,16 +112,20 @@ describe('QualityScannerService', () => {
     });
 
     it('should detect fake lossless (16kHz cutoff)', async () => {
-        vi.mocked(exec).mockImplementation(((cmd: string, cb?: ExecMockCallback) => {
+        vi.mocked(execFile).mockImplementation(((
+            _file: string,
+            args: string[],
+            cb?: ExecMockCallback
+        ) => {
             if (cb) {
-                if (cmd.includes('f=16000')) {
+                if (hasFilter(args, 'f=16000')) {
                     cb(null, { stderr: 'mean_volume: -85.0 dB' });
                 } else {
                     cb(null, { stderr: 'mean_volume: -95.0 dB' });
                 }
             }
-            return { on: vi.fn() } as unknown as ReturnType<typeof exec>;
-        }) as unknown as typeof exec);
+            return { on: vi.fn() } as unknown as ReturnType<typeof execFile>;
+        }) as unknown as typeof execFile);
 
         const report = await scanQualityFile('fake.flac');
         expect(report.isTrueLossless).toBe(false);
@@ -120,16 +133,20 @@ describe('QualityScannerService', () => {
     });
 
     it('should detect likely upsampled files (20kHz cutoff)', async () => {
-        vi.mocked(exec).mockImplementation(((cmd: string, cb?: ExecMockCallback) => {
+        vi.mocked(execFile).mockImplementation(((
+            _file: string,
+            args: string[],
+            cb?: ExecMockCallback
+        ) => {
             if (cb) {
-                if (cmd.includes('f=16000')) {
+                if (hasFilter(args, 'f=16000')) {
                     cb(null, { stderr: 'mean_volume: -50.0 dB' });
                 } else {
                     cb(null, { stderr: 'mean_volume: -90.0 dB' });
                 }
             }
-            return { on: vi.fn() } as unknown as ReturnType<typeof exec>;
-        }) as unknown as typeof exec);
+            return { on: vi.fn() } as unknown as ReturnType<typeof execFile>;
+        }) as unknown as typeof execFile);
 
         const report = await scanQualityFile('upsampled.flac');
         expect(report.isTrueLossless).toBe(false);

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -15,7 +15,7 @@ const SENSITIVE_KEYS = [
     'AI_API_KEY'
 ];
 
-const KNOWN_SETTING_KEYS = [
+export const KNOWN_SETTING_KEYS = [
     'QOBUZ_APP_ID',
     'QOBUZ_APP_SECRET',
     'QOBUZ_USER_AUTH_TOKEN',

--- a/src/utils/binaries.ts
+++ b/src/utils/binaries.ts
@@ -1,4 +1,5 @@
-import { execSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
@@ -6,6 +7,7 @@ import { logger } from './logger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV === 'development';
+const execFileAsync = promisify(execFile);
 
 export interface BinaryInfo {
     path: string;
@@ -58,23 +60,42 @@ export function resolveBinaryPath(binaryName: string): string {
 /**
  * Validates if a binary is available and functional.
  */
+/**
+ * Short-lived memo. Several HTTP routes call this per request; a spawn each
+ * time is wasteful. The TTL keeps it from pinning a "not installed" answer for
+ * the lifetime of the process when the user installs ffmpeg while it runs.
+ */
+const availabilityCache = new Map<string, { info: BinaryInfo; at: number }>();
+const AVAILABILITY_TTL_MS = 60_000;
+
 export async function checkBinaryAvailability(binaryName: string): Promise<BinaryInfo> {
+    const cached = availabilityCache.get(binaryName);
+    if (cached && Date.now() - cached.at < AVAILABILITY_TTL_MS) {
+        return cached.info;
+    }
+
     const binaryPath = resolveBinaryPath(binaryName);
     try {
-        const cmd = `"${binaryPath}" -version`;
-        const output = execSync(cmd, { stdio: 'pipe' }).toString();
-        const firstLine = output.split('\n')[0];
-        
-        return {
+        // argv form and a timeout: this runs on the HTTP request path, and a
+        // synchronous shell spawn with no bound blocked the whole event loop
+        // whenever the binary hung.
+        const { stdout } = await execFileAsync(binaryPath, ['-version'], { timeout: 10000 });
+        const firstLine = stdout.split('\n')[0];
+
+        const info: BinaryInfo = {
             path: binaryPath,
             available: true,
             version: firstLine
         };
+        availabilityCache.set(binaryName, { info, at: Date.now() });
+        return info;
     } catch {
-        return {
+        const info: BinaryInfo = {
             path: binaryPath,
             available: false
         };
+        availabilityCache.set(binaryName, { info, at: Date.now() });
+        return info;
     }
 }
 

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -34,9 +34,19 @@ function getOrGenerateKey(): Buffer {
 
     if (fs.existsSync(ENCRYPTION_KEY_FILE)) {
         try {
-            const keyHex = fs.readFileSync(ENCRYPTION_KEY_FILE, 'utf8');
-            ENCRYPTION_KEY = Buffer.from(keyHex, 'hex');
-            return ENCRYPTION_KEY;
+            const keyHex = fs.readFileSync(ENCRYPTION_KEY_FILE, 'utf8').trim();
+            const parsed = Buffer.from(keyHex, 'hex');
+            // Buffer.from silently truncates at the first invalid hex pair, so
+            // a truncated or corrupted key file used to yield a short (often
+            // zero-length) key. createCipheriv then threw on every write and
+            // decryptSync returned the ciphertext unchanged as "plaintext".
+            if (parsed.length === 32) {
+                ENCRYPTION_KEY = parsed;
+                return ENCRYPTION_KEY;
+            }
+            console.error(
+                'Encryption key file is corrupt, generating new one. Warning: Old encrypted data will be unreadable.'
+            );
         } catch {
             console.error(
                 'Failed to read encryption key, generating new one. Warning: Old encrypted data will be unreadable.'
@@ -50,7 +60,11 @@ function getOrGenerateKey(): Buffer {
         if (!fs.existsSync(dataDir)) {
             fs.mkdirSync(dataDir, { recursive: true });
         }
-        fs.writeFileSync(ENCRYPTION_KEY_FILE, key.toString('hex'), { mode: 0o600 });
+        // Written to a temp file and renamed so an interrupted write cannot
+        // leave a half-length key behind.
+        const tmpPath = `${ENCRYPTION_KEY_FILE}.tmp`;
+        fs.writeFileSync(tmpPath, key.toString('hex'), { mode: 0o600 });
+        fs.renameSync(tmpPath, ENCRYPTION_KEY_FILE);
     } catch (error) {
         console.error('Failed to save encryption key:', error);
     }

--- a/src/utils/net.ts
+++ b/src/utils/net.ts
@@ -1,0 +1,74 @@
+/**
+ * Guards for URLs that arrive in a request body and are then fetched by the
+ * server.
+ *
+ * The cover-art routes take an image URL straight from the caller. Without a
+ * check the dashboard becomes a proxy into whatever the host can reach — the
+ * container network, a metadata service on a link-local address, another
+ * service on loopback — and the response body is written into a file the API
+ * will happily serve back.
+ */
+
+/** Bytes a cover image is allowed to occupy before the fetch is aborted. */
+export const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
+
+/** Redirect hops allowed for a cover fetch. Art hosts routinely 302. */
+export const MAX_IMAGE_REDIRECTS = 3;
+
+const isPrivateIpv4 = (hostname: string): boolean => {
+    const parts = hostname.split('.');
+    if (parts.length !== 4) return false;
+
+    const octets = parts.map((part) => Number(part));
+    if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return false;
+
+    const [a, b] = octets as [number, number, number, number];
+    if (a === 0 || a === 10 || a === 127) return true;
+    if (a === 169 && b === 254) return true; // link-local, incl. cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
+    return false;
+};
+
+const isPrivateIpv6 = (hostname: string): boolean => {
+    const address = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    if (address === '::' || address === '::1') return true;
+    if (address.startsWith('fe80:')) return true; // link-local
+    if (/^f[cd][0-9a-f]{2}:/.test(address)) return true; // unique local
+
+    // ::ffff:127.0.0.1 and friends
+    const mapped = address.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped?.[1]) return isPrivateIpv4(mapped[1]);
+
+    return false;
+};
+
+/**
+ * True when `candidate` is a plain http(s) URL that does not obviously point
+ * back at the host or its private network.
+ *
+ * This is a best-effort check, not a complete SSRF defence: a public hostname
+ * can still resolve to a private address (DNS rebinding). It is paired with a
+ * per-hop re-check on redirects at the call sites.
+ */
+export const isPublicHttpUrl = (candidate: unknown): boolean => {
+    if (typeof candidate !== 'string' || !candidate.trim()) return false;
+
+    let parsed: URL;
+    try {
+        parsed = new URL(candidate);
+    } catch {
+        return false;
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+
+    const hostname = parsed.hostname.toLowerCase();
+    if (!hostname) return false;
+    if (hostname === 'localhost' || hostname.endsWith('.localhost')) return false;
+    if (isPrivateIpv4(hostname)) return false;
+    if (isPrivateIpv6(hostname)) return false;
+
+    return true;
+};


### PR DESCRIPTION
> ## ⚠️ Merge order: **this PR first**
>
> Three PRs came out of the same audit of `v5.5.1`: **#119 (this one)**, #118 and #117.
>
> **Merge this one first, and do not cut a release before it lands.** It is the only
> one of the three that fixes issues an attacker can reach in the shipping build.
> Releasing #117 or #118 first would put out a build advertising fixes while the
> live security issues are still present.
>
> | Order | PR | Why |
> | :---: | --- | --- |
> | **1** | **#119 — security (this PR)** | Fixes live, reachable issues in `v5.5.1` |
> | 2 | #118 — download/queue/UI bug fixes | Shares 3 files with this PR |
> | 3 | #117 — macOS release signing | Independent; shares no files with either |
>
> **No rebase is needed in any order.** I tested all three merge orders against `main`:
> every one merges clean. #118 touches the same three files as this PR
> (`electron/main.cjs`, `src/services/database/index.ts`, `src/services/download.ts`)
> but in different regions, so git auto-merges them. #117 shares no files with either.
> Merging all three produces a tree I verified byte-for-byte against the full audit
> branch, which passes the complete gate.
>
> The order above is about **release safety**, not mechanics.

---

> **These fixes were derived from the latest release, `v5.5.1` (tag `v5.5.1`, commit `9f95524`).**
> **They apply to the published build and affect installed users today — they are not regressions in unreleased work.**

## Scope

A hardening pass over the dashboard server, the helper-binary call sites, the outbound request paths and the Electron shell.

**Technical detail is deliberately withheld from this PR.** Per `SECURITY.md`, the reproductions, affected request paths and impact assessment have been sent to @ifauzeee privately. I'd suggest merging and cutting a release before any of that is discussed publicly. Happy to expand on anything here privately in the meantime.

## What changed

### Authentication and transport
- The dashboard password guard classified request paths in a way that could disagree with how Express actually routes them. The comparison now matches Express's behaviour, and `case sensitive routing` is enabled so the guard and the router cannot diverge again.
- Added an `Origin` check for state-changing requests, and a `Host` check for loopback binds that nothing else authenticates. The `Host` check is deliberately scoped so reverse-proxied LAN/Docker deployments keep working.
- Added an origin check to the socket.io handshake. WebSocket upgrades are not covered by the same-origin policy, and socket.io only installs CORS when `cors` is set.
- Stopped accepting the password from the query string (it lands in access logs, `Referer` and browser history); restricted the `/api/themes` auth exemption to read methods; gave the login routes a dedicated rate limiter.

### Process invocation
- Replaced shell-string invocation with `execFile` and an argv array in `QualityScannerWorker`, the library-scanner worker, `FormatConverterService` and the binary probe, so no file path or setting value is ever parsed by a shell.
- Constrained `EXPORT_FORMAT` and `EXPORT_BITRATE` to known values.
- Gave the binary probe a timeout and moved it off the synchronous path, where it could block the event loop.

### Outbound requests and stored secrets
- Restricted caller-supplied cover-art URLs to public http(s) hosts, re-checking **each redirect hop**, and bounded the response size. New shared helper in `src/utils/net.ts`.
- Restricted media-server URLs to http(s), added timeouts to the notification calls, and moved Plex/Jellyfin tokens out of the query string into headers.
- Restricted encrypted config import to known setting keys — `settingsService.setMany` mirrors every key it is given into `process.env`.
- Validated the encryption key's length before use and made the key file write atomic. A short key previously broke every write while `decryptSync` silently returned ciphertext as "plaintext".
- Escaped `LIKE` metacharacters in the queries that use them, bounded pagination (SQLite reads a negative `LIMIT` as unlimited), and capped the honoured Qobuz `Retry-After`.

### Electron shell
- Allowlisted schemes before `shell.openExternal`.
- Added a `will-navigate` guard so the privileged preload bridge cannot travel to another origin.
- Required `https` for `QBZ_UPDATE_URL` feeds (`autoDownload` and `autoInstallOnAppQuit` are both on).
- Restricted `desktop:open-folder` to directories.
- Added a handshake token so the window only loads a backend this process started, rather than whatever answers on the port.

## Compatibility notes

- The app's own client is unaffected: it authenticates with the `x-password` header and connects socket.io same-origin.
- Non-browser clients (CLI, scripts, tests) send no `Origin` and are still allowed.
- Docker/reverse-proxy deployments are unaffected by the `Host` check, which only applies to loopback binds with no other authentication.

## Verification

Run on this branch:

| Check | Result |
| --- | --- |
| `npm run lint` | 0 errors |
| `npx tsc --noEmit` | clean |
| `npm test` | 250 passed (31 files) |
| `cd client && npm run lint` | 0 errors |
| `cd client && npm test` | 82 passed |
| `npm audit --audit-level=high` | 0 vulnerabilities (root + client) |
| `node tests/electron-smoke.mjs` | passed |

New regression tests cover the auth guard and the URL handling; I confirmed the auth-guard tests fail against the current release code and pass with the fix. The guards were also exercised against a running packaged build.

## Known follow-up

`electron/main.cjs` still sets `sandbox: false`. The preload only uses `contextBridge`/`ipcRenderer`, so `sandbox: true` should work, but I couldn't verify the IPC bridge end-to-end (window controls, folder picker) without driving the UI, so I left it alone rather than ship an unverified change to the shell. Worth a follow-up with a manual smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
