### PR TITLE
fix(desktop): keep stored download path across restarts (#137)

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -400,7 +400,13 @@ async function startBackend() {
     process.env.QBZ_DESKTOP = '1';
     process.env.QBZ_DESKTOP_TOKEN = DESKTOP_HANDSHAKE_TOKEN;
     process.env.NODE_ENV = process.env.NODE_ENV || (app.isPackaged ? 'production' : 'development');
-    process.env.DOWNLOADS_PATH = process.env.DOWNLOADS_PATH || path.join(app.getPath('downloads'), 'QBZ-Downloader');
+    // Default download folder for desktop installs. Exported through a separate
+    // variable (never DOWNLOADS_PATH) so the settings init cannot mistake this
+    // default for explicit user config and overwrite the stored path (issue #137).
+    // An explicitly set DOWNLOADS_PATH keeps working untouched.
+    if (!process.env.DOWNLOADS_PATH) {
+      process.env.QBZ_DEFAULT_DOWNLOADS_PATH = path.join(app.getPath('downloads'), 'QBZ-Downloader');
+    }
 
     const serverEntry = path.join(baseAppPath, 'dist', 'index.js');
     await import(pathToFileURL(serverEntry).href);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -108,3 +108,38 @@ describe('CONFIG environment fallback (server / container installs)', () => {
         expect(CONFIG.dashboard.host).toBe('127.0.0.1');
     });
 });
+
+describe('CONFIG desktop download-path default (issue #137)', () => {
+    afterEach(() => {
+        process.env = { ...originalEnv };
+        vi.resetModules();
+        vi.doUnmock('./services/settings.js');
+    });
+
+    it('uses QBZ_DEFAULT_DOWNLOADS_PATH when nothing is stored and DOWNLOADS_PATH is unset', async () => {
+        delete process.env.DOWNLOADS_PATH;
+        process.env.QBZ_DEFAULT_DOWNLOADS_PATH = 'C:/Users/Downloads/QBZ-Downloader';
+
+        const { CONFIG } = await loadConfigWithSettings({});
+
+        expect(CONFIG.download.outputDir).toBe('C:/Users/Downloads/QBZ-Downloader');
+    });
+
+    it('keeps the stored path when only the desktop default is present', async () => {
+        delete process.env.DOWNLOADS_PATH;
+        process.env.QBZ_DEFAULT_DOWNLOADS_PATH = 'C:/Users/Downloads/QBZ-Downloader';
+
+        const { CONFIG } = await loadConfigWithSettings({ DOWNLOADS_PATH: 'D:/Music' });
+
+        expect(CONFIG.download.outputDir).toBe('D:/Music');
+    });
+
+    it('lets an explicit DOWNLOADS_PATH win over the desktop default', async () => {
+        process.env.DOWNLOADS_PATH = 'E:/Explicit';
+        process.env.QBZ_DEFAULT_DOWNLOADS_PATH = 'C:/Users/Downloads/QBZ-Downloader';
+
+        const { CONFIG } = await loadConfigWithSettings({});
+
+        expect(CONFIG.download.outputDir).toBe('E:/Explicit');
+    });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -229,7 +229,14 @@ export const CONFIG: Config = {
 
     get download() {
         return getCachedConfig('download', () => ({
-            outputDir: getStr('DOWNLOADS_PATH', './downloads'),
+            // The desktop shell exports its OS download folder through
+            // QBZ_DEFAULT_DOWNLOADS_PATH (never DOWNLOADS_PATH), so this
+            // fallback default can never be mistaken for explicit user config
+            // and overwrite the stored path on restart (issue #137).
+            outputDir: getStr(
+                'DOWNLOADS_PATH',
+                process.env.QBZ_DEFAULT_DOWNLOADS_PATH || './downloads'
+            ),
             folderStructure: getStr('FOLDER_TEMPLATE', '{albumArtist}/{album}'),
             fileNaming: getStr('FILE_TEMPLATE', '{track_number}. {title}'),
             concurrent: getInt('MAX_CONCURRENCY', 2),


### PR DESCRIPTION
Fixes #137. Custom download path reverted to the OS default on every restart.

## Root cause

Two pieces interacting badly:

1. `electron/main.cjs` injected the desktop default through `DOWNLOADS_PATH` on every boot.
2. Since `0b8919a`, every env var present at boot is upserted into `app_settings`, overwriting the stored value (correct for containers, wrong for an injected default).

So saving worked (DB + cache updated, effective for the session), but the next restart clobbered the row with the default before anything read it.

## Fix

Separate the "default" channel from the "explicit config" channel:

- `electron/main.cjs`: default goes to `QBZ_DEFAULT_DOWNLOADS_PATH`, and only when `DOWNLOADS_PATH` is not explicitly set.
- `src/config.ts`: `outputDir` falls back to `QBZ_DEFAULT_DOWNLOADS_PATH`, then `./downloads`. The settings-init loop only iterates `KNOWN_SETTING_KEYS`, so a default can never overwrite the DB again. Explicit `DOWNLOADS_PATH` (compose files, power users) keeps winning exactly as before.

## Tests

- 3 new regression tests in `src/config.test.ts` (`CONFIG desktop download-path default (issue #137)`): default used when nothing stored (failed before the fix), stored value survives, explicit env wins.
- Existing env-wins tests in `settings.test.ts` untouched and green (container contract preserved).
- Full suite: 32 files / 262 tests pass; `tsc --noEmit` and ESLint clean.

## Note for the reporter

If the stored row was already overwritten by the default, it cannot be recovered — set the path once more after this fix and it will stick permanently.
