### PR TITLE
chore(release): bump to 5.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.5.3] - 2026-09-08
+
+### Fixed
+- **Download path resets on restart (desktop)** — The Electron shell injected its default folder through `DOWNLOADS_PATH` on every boot, and the settings init (since #119-follow-up `0b8919a`) mistook it for explicit config and overwrote the stored value. The default is now exported through `QBZ_DEFAULT_DOWNLOADS_PATH` and only used as a fallback, so a custom path survives restarts (see #137, PR #150). If your path was already reset, set it once more and it will stick.
+- **Transitive audit failures** — `qs`, `fast-uri`, `@xmldom/xmldom`, `@humanfs/node` bumped past their advisories via `npm audit fix` (lockfile only); `npm audit --audit-level=high` is clean in root and client (see PR #145).
+
+### Changed
+- **Node.js >= 22 required** (`engines`) — Vitest 5 needs Node 22+ and Vite 6.4+ (see PR #145).
+- **Vitest 4 → 5** (backend + client, with `@vitest/coverage-v8` in lockstep) — client `setupTests.ts` now imports `@testing-library/jest-dom/vitest`, required since Vitest 5 inlines the `expect` package (see PR #146, #147).
+- **Dependabot: lockstep `vitest` group** — `vitest` + `@vitest/*` always update in one PR so solo majors can no longer break `npm ci` with ERESOLVE (see PR #145).
+- Dependency refresh: `express-rate-limit` 8.7.0, `p-limit` 7.3.2, `zod` 4.5.x, `electron` 44.2.0, `eslint` 10.10.0 (see #138, #148, #149).
+
 ## [5.5.2] - 2026-08-11
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # 🎵 QBZ-Downloader
 ### The Ultimate High-Resolution Audio Downloader & Library Manager
 
-[![Version](https://img.shields.io/badge/version-5.5.2-6366f1?style=for-the-badge&logo=github)](https://github.com/ifauzeee/QBZ-Downloader/releases)
+[![Version](https://img.shields.io/badge/version-5.5.3-6366f1?style=for-the-badge&logo=github)](https://github.com/ifauzeee/QBZ-Downloader/releases)
 [![Windows](https://img.shields.io/badge/Windows-EXE-0078d4?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/ifauzeee/QBZ-Downloader/releases/latest)
 [![macOS](https://img.shields.io/badge/macOS-DMG-000000?style=for-the-badge&logo=apple)](https://github.com/ifauzeee/QBZ-Downloader/releases/latest)
 [![Linux](https://img.shields.io/badge/Linux-AppImage-fcc624?style=for-the-badge&logo=linux)](https://github.com/ifauzeee/QBZ-Downloader/releases/latest)

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qbz-downloader-client",
   "private": true,
-  "version": "5.5.2",
+  "version": "5.5.3",
   "type": "module",
   "engines": {
     "node": ">=22.0.0"

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "QBZ Downloader",
     "short_name": "QBZ-DL",
-    "version": "5.5.2",
+    "version": "5.5.3",
     "start_url": "/",
     "display": "standalone",
     "theme_color": "#0070f3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbz-downloader",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "Desktop-first Qobuz downloader EXE with Hi-Res audio, metadata automation, and lyrics support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump for the v5.5.3 desktop release (fix #137 + dependency refresh). See CHANGELOG.md for details.